### PR TITLE
fix shebang: remove empty line

### DIFF
--- a/c/build_all/linux/build.sh
+++ b/c/build_all/linux/build.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 #set -o pipefail
 #
@@ -94,7 +93,7 @@ color ()
         tty -s && tput setaf 2
         return 0
     fi
-    
+
     if [ "$1" == "cyan" ]
     then
         tty -s && tput setaf 6


### PR DESCRIPTION
While working on resin.io integration project I've found a tiny error that made the build script non-working for example on the recent Raspbian.

Apparently the shebang must be the very first line of the script, otherwise it's treated as a regular comment. As the result on systems that have minimal /bin/sh as their default shell the script fails because pushd is not defined (it's bash extension).

// moved from https://github.com/Azure/azure-iot-suite-sdks/pull/58#issuecomment-144119831