### PR TITLE
Download proton as zip

### DIFF
--- a/c/build_all/linux/build_proton.sh
+++ b/c/build_all/linux/build_proton.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-proton_repo="https://github.com/dcristoloveanu/qpid-proton.git"
+proton_repo="https://github.com/dcristoloveanu/qpid-proton"
 proton_branch="0.9-IoTClient"
 build_root=
 
@@ -40,7 +40,7 @@ process_args ()
             build_root="$2"
         elif [ "$1" == "-i" ] || [ "$1" == "--install" ]
         then
-            install_root="$2" 
+            install_root="$2"
         else
             usage
         fi
@@ -69,8 +69,13 @@ sync_proton ()
     fi
 
     rm $build_root -r -f
-    mkdir $build_root
-    git clone -b $proton_branch $proton_repo $build_root
+    cd /tmp
+    curl -L $proton_repo/archive/$proton_branch.zip -o proton.zip
+    mkdir proton
+    unzip proton.zip -d proton
+    mv ./proton/qpid-proton-$proton_branch/ $build_root/
+    rm proton.zip
+    rm -rf proton
 }
 
 build ()

--- a/c/build_all/linux/setup.sh
+++ b/c/build_all/linux/setup.sh
@@ -12,7 +12,7 @@ repo_name_from_uri()
 }
 
 scriptdir=$(cd "$(dirname "$0")" && pwd)
-deps="curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake git"
+deps="curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake unzip openjdk-7-jre"
 repo="https://github.com/Azure/azure-iot-sdks.git"
 repo_name=$(repo_name_from_uri $repo)
 cred=~/cred.$$
@@ -51,7 +51,7 @@ creds_create ()
 	host=$host
 	username=$user
 	password=$pass
-	
+
 	end-credentials
 }
 

--- a/c/doc/run_sample_on_beaglebone_black_debian.md
+++ b/c/doc/run_sample_on_beaglebone_black_debian.md
@@ -49,7 +49,7 @@ Run the following commands in the terminal window connected to your BeagleBone B
 
   ```
   sudo apt-get update
-  sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake git
+  sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake unzip openjdk-7-jre
   ```
   If you get errors running sudo, make sure your root password is set as decribed above.
 

--- a/c/doc/run_sample_on_beaglebone_black_snappy.md
+++ b/c/doc/run_sample_on_beaglebone_black_snappy.md
@@ -187,7 +187,7 @@ To run this tool, you need connection and configuration information for your IoT
 - Install the prerequisite packages by issuing the following commands from the command line on the board:
 
 		sudo apt-get update
-		sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake git
+		sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake unzip openjdk-7-jre
 
 - Download the SDK to the board by issuing the following command in PuTTY:
 

--- a/c/doc/run_sample_on_beaglebone_green.md
+++ b/c/doc/run_sample_on_beaglebone_green.md
@@ -47,7 +47,7 @@ Before you begin you will need to create and configure an IoT hub to connect to.
 
   ```
   sudo apt-get update
-  sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake git
+  sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake unzip openjdk-7-jre
   ```
 
   **Note:** You can paste into a PuTTY terminal window in Windows by using mouse right-click.

--- a/c/doc/run_sample_on_raspberrypi2_raspbian.md
+++ b/c/doc/run_sample_on_raspberrypi2_raspbian.md
@@ -78,7 +78,7 @@ Run the following commands in the terminal window connected to your Raspberry Pi
 
   ```
   sudo apt-get update
-  sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake git
+  sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake unzip openjdk-7-jre
   ```
   If you get errors running sudo, make sure your root password is set as decribed above.
 

--- a/c/serializer/samples/remote_monitoring/linux/readme.txt
+++ b/c/serializer/samples/remote_monitoring/linux/readme.txt
@@ -2,17 +2,17 @@ How to have a running the remote monitoring sample on Ubuntu 14.04 LTS
 
 1. Get a virtual machine in Azure. (New->Compute->Virtual Machine->Quick Create). Use Ubuntu Server 14.04 LTS, Size "A1".
 2. Once the virtual machine has been created, SSH into it (putty is a nice ssh tool on windows). Notice that the only user name available at this time is "azureuser"
-3. The following are packages needed: git, cmake, uuid-dev, libcurl4-openssl-dev, g++. They can all be installed with one command:
+3. The following are packages needed: unzip, openjdk-7-jre, cmake, uuid-dev, libcurl4-openssl-dev, g++. They can all be installed with one command:
 
-sudo apt-get install git cmake uuid-dev libcurl4-openssl-dev g++ 
+sudo apt-get install unzip openjdk-7-jre cmake uuid-dev libcurl4-openssl-dev g++
 
-4. Once these packages have been installed, clone the repository by using 
+4. Once these packages have been installed, clone the repository by using
 
 git clone https://github.com/Azure/azure-iot-sdks.git
 
     It will prompt for a user name and a password. The password needs to be a token from github.com : Personal Settings -> Applications -> Personal access tokens. It cannot be the account password.
 
-5. Switch to directory azure-iot-sdks 
+5. Switch to directory azure-iot-sdks
 
 cd azure-iot-sdks
 

--- a/c/serializer/samples/simplesample_amqp/linux/readme.txt
+++ b/c/serializer/samples/simplesample_amqp/linux/readme.txt
@@ -2,17 +2,17 @@ How to have a running simplesample_amqp on Ubuntu 14.04 LTS
 
 1. Get a virtual machine in Azure. (New->Compute->Virtual Machine->Quick Create). Use Ubuntu Server 14.04 LTS, Size "A1".
 2. Once the virtual machine has been created, SSH into it (putty is a nice ssh tool on windows). Notice that the only user name available at this time is "azureuser"
-3. The following are packages needed: git, cmake, uuid-dev, libcurl4-openssl-dev, g++. They can all be installed with one command:
+3. The following are packages needed: unzip, openjdk-7-jre, cmake, uuid-dev, libcurl4-openssl-dev, g++. They can all be installed with one command:
 
-sudo apt-get install git cmake uuid-dev libcurl4-openssl-dev g++ 
+sudo apt-get install unzip openjdk-7-jre cmake uuid-dev libcurl4-openssl-dev g++
 
-4. Once these packages have been installed, clone the repository by using 
+4. Once these packages have been installed, clone the repository by using
 
 git clone https://github.com/Azure/azure-iot-sdks.git
 
     It will prompt for a user name and a password. The password needs to be a token from github.com : Personal Settings -> Applications -> Personal access tokens. It cannot be the account password.
 
-5. Switch to directory azure-iot-sdks 
+5. Switch to directory azure-iot-sdks
 
 cd azure-iot-sdks
 

--- a/doc/iotcertification/iot_certification_linux_c/iot_certification_linux_c.md
+++ b/doc/iotcertification/iot_certification_linux_c/iot_certification_linux_c.md
@@ -29,8 +29,8 @@ How to certify IoT devices running Linux with Azure IoT SDK
 
 This document provides step-by-step guidance to IoT hardware publishers on how
 to certify an IoT enabled hardware with Azure IoT SDK. This multi-step process
-includes: 
--   Configuring Azure IoT Hub 
+includes:
+-   Configuring Azure IoT Hub
 -   Registering your IoT device
 -   Build and deploy Azure IoT SDK on device
 -   Packaging and sharing the logs
@@ -50,12 +50,12 @@ You should have the following items ready before beginning the process:
 -   Required hardware to certify.
 
 ***Note:*** *If you haven’t contacted Microsoft about being an Azure Certified for IoT partner, please submit this [form](<https://iotcert.cloudapp.net/>) first to request it and then follow these instructions.*
-    
+
 <a name="Step_1:_Configure"/>
 
 # Step 1: Sign Up To Azure IoT Hub
 
-Follow the instructions [here](https://account.windowsazure.com/signup?offer=ms-azr-0044p) on how to sign up to the Azure IoT Hub service. As part of the sign up process, you will receive the connection string. 
+Follow the instructions [here](https://account.windowsazure.com/signup?offer=ms-azr-0044p) on how to sign up to the Azure IoT Hub service. As part of the sign up process, you will receive the connection string.
 
 -   **IoT Hub Connection String**: An example of IoT Hub Connection String is as below:
 
@@ -81,7 +81,7 @@ To run Device Explorer tool, use following configuration string as described in
 [Step1](#Step_1:_Configure):
 
 -   IoT Hub Connection String
-    
+
 
 **Steps:**
 1.  Click [here](<https://github.com/Azure/azure-iot-sdks/blob/develop/tools/DeviceExplorer/doc/how_to_use_device_explorer.md>) to download and install Device Explorer.
@@ -131,17 +131,15 @@ Azure IoT SDK.
 
     **Debian or Ubuntu**
 
-        sudo apt-get update 
+        sudo apt-get update
 
-        sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake git 
-
-        sudo apt-get install -y uuid-dev uuid 
+        sudo apt-get install -y curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake unzip openjdk-7-jre
 
     **Fedora**
 
-        sudo dnf check-update -y 
+        sudo dnf check-update -y
 
-        sudo dnf install libcurl-devel openssl-devel libuuid-devel uuid-devel gcc-c++ make cmake git      
+        sudo dnf install libcurl-devel openssl-devel libuuid-devel uuid-devel gcc-c++ make cmake unzip java-1.7.0-openjdk
 
     **Any Other Linux OS**
 
@@ -234,19 +232,19 @@ In this section you will run the end to end test cases for Azure IoT client SDK 
     -   **IOTHUB_EVENTHUB_LISTEN_NAME:** Name of your Event Hub
     -   **IOTHUB_NAME:** Name of your IoT Hub
     -   **IOTHUB_SHARED_ACCESS_SIGNATURE:** this value can be generated from Device Explorer
-    
+
         Go to **Configuration** tab &minus;&gt; Click **Generate SAS** button
     -   **IOTHUB_SUFFIX:** Suffix of your IoT Hub hostname in connection string
     -   **IOTHUB_PARTITION_COUNT:** Set value as **16**
-    -   **IOTHUB_POLICY_NAME:** ToDo 
+    -   **IOTHUB_POLICY_NAME:** ToDo
     -   **IOTHUB_POLICY_KEY:** ToDo
-    
+
 
 -   Set environment variables by running following command on your device:
 
         cd ./azure-iot-sdks/tools/iot_hub_e2e_tests_params/
         chmod +x setiotdeviceparametersfore2etests.sh
-        sudo setiotdeviceparametersfore2etests.sh 
+        sudo setiotdeviceparametersfore2etests.sh
 
 ### 3.3.2 Run End to End test cases
 


### PR DESCRIPTION
At resin.io we build apps in the cloud. For me the git clone step has been hanging several times, and was really slow overall. Also it feels like it's a significant overhead to fetch the repo with all embedded info, as well as the git itself is big compared to unzip.

So I've updated the script to fetch the same sources (but without the extra git history and everything) as a ZIP.

I've also noticed that proton doesn't build without Java so I've added the JRE dependency.

// original PR https://github.com/Azure/azure-iot-suite-sdks/pull/59