### PR TITLE
Update to adhere to documentation

### DIFF
--- a/node/device/samples/simple_sample_http.js
+++ b/node/device/samples/simple_sample_http.js
@@ -31,7 +31,7 @@ setInterval(function(){
       printResultFor('receive')(err, res);
     }
   });
-}, 1000);
+}, 1500000);
 
 // Helper function to print results in the console
 function printResultFor(op) {


### PR DESCRIPTION
Per the documentation here (https://azure.microsoft.com/en-us/documentation/articles/iot-hub-devguide/#messaging) I am proposing an update to the sample to limit polling for devices messages (C2D pattern) to no more than once per 25-minutes. The samples should reflect the guidance in the documentation or risk teaching the developer community an anti-pattern.

"HTTP/1 does not have an efficient way to implement server push. As such, when using HTTP/1, devices poll IoT Hub for cloud-to-device messages. This is very inefficient for both the device and IoT Hub. The current guidelines, when using HTTP/1 is to set a polling interval for each device of less than once per 25 minutes. "