### PR TITLE
Support for Shared Access Signature in AMQP protocol implementation is completed

### DIFF
--- a/c/iothub_client/inc/iothub_client_amqp_internal.h
+++ b/c/iothub_client/inc/iothub_client_amqp_internal.h
@@ -73,6 +73,8 @@ typedef struct AMQP_TRANSPORT_STATE_TAG
     // Needed for device scoped key names.
     STRING_HANDLE zeroLengthString;
 
+
+    STRING_HANDLE sharedAccessSignature;
     //
     // This is the proton object that controls all aspects of the connection to the cloud.
     //

--- a/c/iothub_client/inc/iothub_client_ll.h
+++ b/c/iothub_client/inc/iothub_client_ll.h
@@ -109,6 +109,8 @@ typedef struct IOTHUB_CLIENT_CONFIG_TAG
     const char* iotHubSuffix;
 
     const char* protocolGatewayHostName;
+
+    const char* sharedAccessSignature;
 } IOTHUB_CLIENT_CONFIG;
 
 /**

--- a/c/iothub_client/src/iothub_client_ll.c
+++ b/c/iothub_client/src/iothub_client_ll.c
@@ -34,6 +34,7 @@ typedef struct IOTHUB_CLIENT_LL_HANDLE_DATA_TAG
 static const char HOSTNAME_TOKEN[] = "HostName";
 static const char DEVICEID_TOKEN[] = "DeviceId";
 static const char DEVICEKEY_TOKEN[] = "SharedAccessKey";
+static const char SAS_TOKEN[] = "SharedAccessSignature";
 static const char PROTOCOL_GATEWAY_HOST[] = "GatewayHostName";
 
 IOTHUB_CLIENT_LL_HANDLE IoTHubClient_LL_CreateFromConnectionString(const char* connectionString, IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
@@ -73,6 +74,7 @@ IOTHUB_CLIENT_LL_HANDLE IoTHubClient_LL_CreateFromConnectionString(const char* c
             STRING_HANDLE hostSuffixString = NULL;
             STRING_HANDLE deviceIdString = NULL;
             STRING_HANDLE deviceKeyString = NULL;
+            STRING_HANDLE sasString = NULL;
             STRING_HANDLE protocolGateway = NULL;
 
             config->protocol = protocol;
@@ -81,6 +83,7 @@ IOTHUB_CLIENT_LL_HANDLE IoTHubClient_LL_CreateFromConnectionString(const char* c
             config->iotHubSuffix = NULL;
             config->deviceId = NULL;
             config->deviceKey = NULL;
+            config->sharedAccessSignature = NULL;
 			/* Codes_SRS_IOTHUBCLIENT_LL_04_002: [If it does not, it shall pass the protocolGatewayHostName NULL.] */
 			config->protocolGatewayHostName = NULL;
 
@@ -174,8 +177,18 @@ IOTHUB_CLIENT_LL_HANDLE IoTHubClient_LL_CreateFromConnectionString(const char* c
                                 if (deviceKeyString != NULL)
                                 {
                                     config->deviceKey = STRING_c_str(deviceKeyString);
+                                    config->sharedAccessSignature = NULL;
                                 }
                             }
+                            else if (strcmp(s_token, SAS_TOKEN) == 0)
+                            {
+                            	sasString = STRING_clone(valueString);
+							   if (sasString != NULL)
+							   {
+								   config->sharedAccessSignature = STRING_c_str(sasString);
+								   config->deviceKey = NULL;
+							   }
+						   }
 							/* Codes_SRS_IOTHUBCLIENT_LL_04_001: [IoTHubClient_LL_CreateFromConnectionString shall verify the existence of key/value pair GatewayHostName. If it does exist it shall pass the value to IoTHubClient_LL_Create API.] */
                             else if (strcmp(s_token, PROTOCOL_GATEWAY_HOST) == 0)
                             {
@@ -201,9 +214,9 @@ IOTHUB_CLIENT_LL_HANDLE IoTHubClient_LL_CreateFromConnectionString(const char* c
                 {
                     LogError("deviceId is not found\r\n");
                 }
-                else if (config->deviceKey == NULL)
+                else if (config->deviceKey == NULL && config->sharedAccessSignature == NULL)
                 {
-                    LogError("deviceId is not found\r\n");
+                    LogError("deviceKey/SaS is not found\r\n");
                 }
                 else
                 {
@@ -217,6 +230,8 @@ IOTHUB_CLIENT_LL_HANDLE IoTHubClient_LL_CreateFromConnectionString(const char* c
             }
             if (deviceKeyString != NULL)
                 STRING_delete(deviceKeyString);
+            if (sasString != NULL)
+                STRING_delete(sasString);
             if (deviceIdString != NULL)
                 STRING_delete(deviceIdString);
             if (hostSuffixString != NULL)


### PR DESCRIPTION
To support Shared Access Signature implementation in Amqp protocol was completed. SAS token needs to be passed in connection string to create respective iothub_client. 