### PR TITLE
fix TI-RTOS build and time() related issues

### DIFF
--- a/c/doc/run_sample_on_ti_cc3200.md
+++ b/c/doc/run_sample_on_ti_cc3200.md
@@ -54,6 +54,10 @@ While not strictly required, we recommend that you install the following tools f
   ti.targets.arm.elf.M4  ?= C:/ti/ti-cgt-arm_5.2.5
   ```
 
+TI ARM compiler will build the C runtime library when the make is run the first time. This build requires gmake.exe and searchs it on the environment path. It is recommended that you add the folder containing gmake.exe to your path. Alternately, XDCtools product (```C:/ti/xdctools_3_31_01_33_core```) which also contains gmake.exe can be added to the path. But note, it is recommended to remove the XDCtools from the path after the libraries are built to avoid conflicts when you use newer versions of XDCtools.
+
+For detailed information about building TI's C runtime library, please read the [Mklib wiki](http://processors.wiki.ti.com/index.php/Mklib).
+
 2. Open a Windows command prompt.
 
 3. In the Windows command prompt, run the following commands (be sure to replace the paths with your installation paths).

--- a/c/doc/run_sample_on_ti_cc3200.md
+++ b/c/doc/run_sample_on_ti_cc3200.md
@@ -38,7 +38,7 @@ While not strictly required, we recommend that you install the following tools f
 
 - Install [TI-RTOS SDK for SimpleLink](http://downloads.ti.com/dsps/dsps_public_sw/sdo_sb/targetcontent/tirtos/index.html) 2.14.01.20 or above
 
-- Install [NS package](http://software-dl.ti.com/dsps/dsps_public_sw/sdo_sb/targetcontent/ns/ns_1_10_00_00_eng.zip). Please note, the NS package is a pre-release version. It's content and the download location are subject to change.
+- Install [NS package](http://software-dl.ti.com/dsps/dsps_public_sw/sdo_sb/targetcontent/ns/ns_1_10_00_03.zip). Please note, the NS package is a pre-release version. It's content and the download location are subject to change.
 
 - Install [TI ARM Compiler](http://software-dl.ti.com/ccs/esd/test/ti_cgt_tms470_5.2.5_windows_installer.exe) 5.2.2 or above
 
@@ -49,7 +49,7 @@ While not strictly required, we recommend that you install the following tools f
   ```
   XDCTOOLS_INSTALLATION_DIR ?= C:/ti/xdctools_3_31_01_33_core
   TIRTOS_INSTALLATION_DIR ?= C:/ti/tirtos_simplelink_2_14_01_20
-  NS_INSTALLATION_DIR     ?= C:/ti/ns_1_10_00_00_eng
+  NS_INSTALLATION_DIR     ?= C:/ti/ns_1_10_00_03
   CC3200SDK_INSTALLATION_DIR ?= C:/ti/CC3200SDK_1.1.0/cc3200-sdk
   ti.targets.arm.elf.M4  ?= C:/ti/ti-cgt-arm_5.2.5
   ```
@@ -73,8 +73,6 @@ Before building the application, complete the following steps:
 2. Open the file `tirtos/cc3200/main.c`. Search for "USER STEP" and update the current date-time macros.
 
 3. Open the file `tirtos/cc3200/wificonfig.h`. Search for "USER STEP" and update the WIFI SSID and SECURITY_KEY macros.
-
-4. Download the [elf2cc32 executable for Windows](https://github.com/tisb-vikram/azure-iot-sdks/blob/7da24633b2c4af3bc779998e9950146f061a8a10/c/serializer/samples/simplesample_http/tirtos/cc3200/tools/elf2cc32.exe?raw=true) or [elf2cc32 executable for Linux](https://github.com/tisb-vikram/azure-iot-sdks/blob/7da24633b2c4af3bc779998e9950146f061a8a10/c/serializer/samples/simplesample_http/tirtos/cc3200/tools/elf2cc32?raw=true) to the folder <AZURE_INSTALL_DIR>\azure-iot-sdks\c\serializer\samples\simplesample_http\tirtos\cc3200\tools. This tool is needed for converting the simplesample_http.out to simplesample_http.bin file.
 
 In the Windows command prompt, enter the following commands to build the application:
 

--- a/c/doc/run_sample_on_ti_cc3200.md
+++ b/c/doc/run_sample_on_ti_cc3200.md
@@ -38,7 +38,7 @@ While not strictly required, we recommend that you install the following tools f
 
 - Install [TI-RTOS SDK for SimpleLink](http://downloads.ti.com/dsps/dsps_public_sw/sdo_sb/targetcontent/tirtos/index.html) 2.14.01.20 or above
 
-- Install [NS package](http://software-dl.ti.com/dsps/dsps_public_sw/sdo_sb/targetcontent/ns/ns_1_10_00_03.zip). Please note, the NS package is a pre-release version. It's content and the download location are subject to change.
+- Install [NS package](http://software-dl.ti.com/dsps/dsps_public_sw/sdo_sb/targetcontent/ns/ns_1_10_00_03.zip).
 
 - Install [TI ARM Compiler](http://software-dl.ti.com/ccs/esd/test/ti_cgt_tms470_5.2.5_windows_installer.exe) 5.2.2 or above
 

--- a/c/serializer/samples/simplesample_http/tirtos/cc3200/main.cfg
+++ b/c/serializer/samples/simplesample_http/tirtos/cc3200/main.cfg
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Texas Instruments Incorporated
+ * Copyright (c) 2015-2016, Texas Instruments Incorporated
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,7 @@ var Clock = xdc.useModule('ti.sysbios.knl.Clock');
 var Task = xdc.useModule('ti.sysbios.knl.Task');
 var Semaphore = xdc.useModule('ti.sysbios.knl.Semaphore');
 var Hwi = xdc.useModule('ti.sysbios.hal.Hwi');
+var Seconds = xdc.useModule('ti.sysbios.hal.Seconds');
 var HeapMem = xdc.useModule('ti.sysbios.heaps.HeapMem');
 var Mailbox = xdc.useModule('ti.sysbios.knl.Mailbox');
 

--- a/c/serializer/samples/simplesample_http/tirtos/cc3200/makedefs
+++ b/c/serializer/samples/simplesample_http/tirtos/cc3200/makedefs
@@ -23,10 +23,10 @@ ifeq ("$(SHELL)","sh.exe")
 #For Windows
         RMDIR  = rmdir /S /Q
         remove = del $(subst /,\,$1)
-        binconv = tools/elf2cc32.exe
+        binconv = $(NS_INSTALLATION_DIR)/tools/elf2cc32.exe
 else
 #For Linux
         RMDIR  = rm -rf
         remove = rm -f $1
-        binconv = tools/elf2cc32
+        binconv = $(NS_INSTALLATION_DIR)/tools/elf2cc32
 endif


### PR DESCRIPTION
These commits contain fixes for incorrect time value and the elfcc32 build issues.