### PR TITLE
Add/update README files for all Node.js packages

### DIFF
--- a/build/release/bump_version/versions.json
+++ b/build/release/bump_version/versions.json
@@ -16,18 +16,18 @@
         "service": "1.0.0-preview.9"
     },
     "node": {
-        "common": "1.0.0-preview.10",
-        "amqp-base": "1.0.0-preview.10",
-        "http-base": "1.0.0-preview.10",
-        "mqtt-base": "1.0.0-preview.10",
-        "device": "1.0.0-preview.10",
-        "device-amqp": "1.0.0-preview.10",
-        "device-amqp-ws": "1.0.0-preview.10",
-        "device-http": "1.0.0-preview.10",
-        "device-mqtt": "1.0.0-preview.10",
-        "service": "1.0.0-preview.10"
+        "common": "1.0.0-preview.11",
+        "amqp-base": "1.0.0-preview.11",
+        "http-base": "1.0.0-preview.11",
+        "mqtt-base": "1.0.0-preview.11",
+        "device": "1.0.0-preview.11",
+        "device-amqp": "1.0.0-preview.11",
+        "device-amqp-ws": "1.0.0-preview.11",
+        "device-http": "1.0.0-preview.11",
+        "device-mqtt": "1.0.0-preview.11",
+        "service": "1.0.0-preview.11"
     },
-    "iothub-explorer": "1.0.0-preview.10",
+    "iothub-explorer": "1.0.0-preview.11",
     "device-explorer": "1.0.0-preview.9",
     "github-release": "v1.0.0-preview.9"
 }

--- a/node/common/core/package.json
+++ b/node/common/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-common",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "Common components shared by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/node/common/core/readme.md
+++ b/node/common/core/readme.md
@@ -1,0 +1,6 @@
+#azure-iot-common
+Internal library of components shared between the Azure IoT device and service SDKs.
+
+[![npm version](https://badge.fury.io/js/azure-iot-common.svg)](https://badge.fury.io/js/azure-iot-common)
+
+NOTE: You generally don't want to reference this package directly. The components you need should be exposed by packages in the device (`azure-iot-device*`) or service (`azure-iothub`) SDKs.

--- a/node/common/transport/amqp/package.json
+++ b/node/common/transport/amqp/package.json
@@ -1,13 +1,13 @@
 {
   "name": "azure-iot-amqp-base",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "AMQP operations used by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
     "amqp10": "^2.2.0",
     "amqp10-transport-ws": "^0.0.2",
-    "azure-iot-common": "1.0.0-preview.10"
+    "azure-iot-common": "1.0.0-preview.11"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/node/common/transport/amqp/readme.md
+++ b/node/common/transport/amqp/readme.md
@@ -1,0 +1,6 @@
+#azure-iot-amqp-base
+Internal library of AMQP-specific components shared between the Azure IoT device and service SDKs.
+
+[![npm version](https://badge.fury.io/js/azure-iot-amqp-base.svg)](https://badge.fury.io/js/azure-iot-amqp-base)
+
+NOTE: You generally don't want to reference this package directly. The AMQP components you need should be exposed by packages in the device (`azure-iot-device-amqp` or `azure-iot-device-amqp-ws`) or service (`azure-iothub`) SDKs.

--- a/node/common/transport/http/package.json
+++ b/node/common/transport/http/package.json
@@ -1,11 +1,11 @@
 {
   "name": "azure-iot-http-base",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "HTTP operations used by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-common": "1.0.0-preview.10"
+    "azure-iot-common": "1.0.0-preview.11"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/node/common/transport/http/readme.md
+++ b/node/common/transport/http/readme.md
@@ -1,0 +1,6 @@
+#azure-iot-http-base
+Internal library of HTTP-specific components shared between the Azure IoT device and service SDKs.
+
+[![npm version](https://badge.fury.io/js/azure-iot-http-base.svg)](https://badge.fury.io/js/azure-iot-http-base)
+
+NOTE: You generally don't want to reference this package directly. The HTTP components you need should be exposed by packages in the device (`azure-iot-device-http`) or service (`azure-iothub`) SDKs.

--- a/node/common/transport/mqtt/package.json
+++ b/node/common/transport/mqtt/package.json
@@ -1,11 +1,11 @@
 {
   "name": "azure-iot-mqtt-base",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "MQTT operations used by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-common": "1.0.0-preview.10",
+    "azure-iot-common": "1.0.0-preview.11",
     "mqtt": "^1.5.0"
   },
   "devDependencies": {

--- a/node/common/transport/mqtt/readme.md
+++ b/node/common/transport/mqtt/readme.md
@@ -1,0 +1,6 @@
+#azure-iot-mqtt-base
+Internal library of MQTT-specific components shared between the Azure IoT device and service SDKs.
+
+[![npm version](https://badge.fury.io/js/azure-iot-mqtt-base.svg)](https://badge.fury.io/js/azure-iot-mqtt-base)
+
+NOTE: You generally don't want to reference this package directly. The MQTT components you need should be exposed by the `azure-iot-device-mqtt` package in the device SDK.

--- a/node/device/core/package.json
+++ b/node/device/core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-iot-device",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "Azure IoT device SDK",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "main": "device.js",
   "dependencies": {
-    "azure-iot-common": "1.0.0-preview.10"
+    "azure-iot-common": "1.0.0-preview.11"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/node/device/core/readme.md
+++ b/node/device/core/readme.md
@@ -1,45 +1,34 @@
-# Microsoft Azure IoT device SDK for Node.js
+#azure-iot-device
+The core components of the Azure IoT device SDK.
 
-The Microsoft Azure IoT device libraries for Node.js contain code that facilitates building devices and applications that connect to and are managed by Azure IoT Hub.
+[![npm version](https://badge.fury.io/js/azure-iot-device.svg)](https://badge.fury.io/js/azure-iot-device)
 
-## Features
+## Install
 
-The IoT device SDK for Node.js libraries enable you to:
-* Send event data to Azure IoT based services.
-* Map server commands to device functions.
-* Batch messages to improve communication efficiency.
-* Support pluggable transport protocols. HTTPS protocol is available now.
+`npm install -g azure-iot-device@latest` to get the latest (pre-release) version.
 
-## Application development guides
-For more information on how to use this library refer to the documents below:
-- [Prepare your node.js development environment](doc/devbox_setup.md)
-- [Setup IoT Hub](../../doc/setup_iothub.md)
-- [Provision devices](../../tools/iothub-explorer/doc/provision_device.md)
-- [Using the DeviceExplorer application to test IoT Hub device connectivity](../../tools/DeviceExplorer/doc/how_to_use_device_explorer.md)
-- [Run the node.js sample application](doc/run_sample.md)
-- [Node API reference](http://azure.github.io/azure-iot-sdks/node/api_reference/azure-iot-device/1.0.0-preview.10/index.html)
+## Getting Started
 
-## Directory structure of repository
+This package contains the core components of the Azure IoT device SDK, but is lacking a transport over which to send events and receive messages. Your application must require a transport package in addition to the core package to do something useful.
 
-All the Node.js specific resources are located in the **node** folder. This folder contains various script files to help you to prepare your development environment. The **node** folder contains the following subfolders:
+For example, if you want to send an event from your device to an IoT Hub _using the AMQP protocol_:
 
-### /build
+```js
+var connectionString = '[IoT Hub device connection string]';
 
-This folder contains various JavaScript build scripts.
+// use factory function from AMQP-specific package
+var clientFromConnectionString = require('azure-iot-device-amqp').clientFromConnectionString;
+// AMQP-specific factory function returns Client object from core package
+var client = clientFromConnectionString(connectionString);
 
-### /common
+// use Message object from core package
+var Message = require('azure-iot-device').Message;
+var msg = new Message('some data from my device');
 
-This folder contains common library code used by both the device and service libraries.
+// send the event
+client.sendEvent(msg, function (err) {
+  if (err) console.log(err.toString());
+});
+```
 
-### /device/doc
-
-This folder contains application development guideline documents:
-
-
-### /device/lib
-
-This folder contains the device SDK library code.
-
-### /device/samples
-
-This folder contains various sample applications that illustrate how to use the device features of the Microsoft Azure IoT SDK for Node.js.
+See the `azure-iot-device-*` transport-specific packages for more information.

--- a/node/device/readme.md
+++ b/node/device/readme.md
@@ -1,0 +1,38 @@
+# Microsoft Azure IoT device SDK for Node.js
+
+Build devices that communicate with Azure IoT Hub.
+
+## Features
+
+Use the device SDK to:
+* Send event data to Azure IoT Hub.
+* Receive messages from IoT Hub.
+* Communicate with the service via AMQP (optionally over WebSockets), MQTT, or HTTP.
+
+## Application development guides
+For more information on how to use this library refer to the documents below:
+- [Prepare your node.js development environment](doc/devbox_setup.md)
+- [Setup IoT Hub](../../doc/setup_iothub.md)
+- [Provision devices](../../tools/iothub-explorer/doc/provision_device.md)
+- [Run a node.js sample application](doc/run_sample.md)
+- [Node API reference](http://azure.github.io/azure-iot-sdks/node/api_reference/azure-iot-device/1.0.0-preview.10/index.html)
+
+## Directory structure
+
+Device SDK subfolders under **node/device**:
+
+### /core
+
+Protocol-independent device SDK package.
+
+### /doc
+
+How-to guides and other information.
+
+### /samples
+
+Sample applications excercising basic features.
+
+### /transport
+
+Protocol-specific SDK packages for: AMQP, AMQP over WebSockets, MQTT, and HTTP.

--- a/node/device/samples/package.json
+++ b/node/device/samples/package.json
@@ -6,10 +6,10 @@
   "author": "Microsoft Corp.",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-device": "1.0.0-preview.10",
-    "azure-iot-device-amqp": "1.0.0-preview.10",
-    "azure-iot-device-http": "1.0.0-preview.10",
-    "azure-iot-device-mqtt": "1.0.0-preview.10"
+    "azure-iot-device": "1.0.0-preview.11",
+    "azure-iot-device-amqp": "1.0.0-preview.11",
+    "azure-iot-device-http": "1.0.0-preview.11",
+    "azure-iot-device-mqtt": "1.0.0-preview.11"
   },
   "devDependencies": {
     "jshint": "^2.8.0"

--- a/node/device/transport/amqp-ws/package.json
+++ b/node/device/transport/amqp-ws/package.json
@@ -1,16 +1,16 @@
 {
   "name": "azure-iot-device-amqp-ws",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "AMQP-over-WebSocket transport for Azure IoT device SDK",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-amqp-base": "1.0.0-preview.10",
-    "azure-iot-device": "1.0.0-preview.10",
-    "azure-iot-device-amqp": "1.0.0-preview.10"
+    "azure-iot-amqp-base": "1.0.0-preview.11",
+    "azure-iot-device": "1.0.0-preview.11",
+    "azure-iot-device-amqp": "1.0.0-preview.11"
   },
   "devDependencies": {
-    "azure-iot-common": "1.0.0-preview.10",
+    "azure-iot-common": "1.0.0-preview.11",
     "chai": "^3.3.0",
     "jshint": "^2.8.0",
     "mocha": "^2.3.3"

--- a/node/device/transport/amqp-ws/readme.md
+++ b/node/device/transport/amqp-ws/readme.md
@@ -1,0 +1,46 @@
+#azure-iot-device-amqp-ws
+Communicate with Azure IoT Hub from any device using AMQP over WebSockets.
+
+[![npm version](https://badge.fury.io/js/azure-iot-device-amqp-ws.svg)](https://badge.fury.io/js/azure-iot-device-amqp-ws)
+
+## Install
+
+`npm install -g azure-iot-device-amqp-ws@latest` to get the latest (pre-release) version.
+
+## Getting Started
+
+Create a device client:
+
+```js
+var clientFromConnectionString = require('azure-iot-device-amqp-ws').clientFromConnectionString;
+var Message = require('azure-iot-device').Message;
+
+var connectionString = '[IoT Hub device connection string]';
+
+var client = clientFromConnectionString(connectionString);
+```
+
+Send an event:
+
+```js
+var msg = new Message('some data from my device');
+client.sendEvent(message, function (err) {
+  if (err) console.log(err.toString());
+});
+```
+
+Receive a message, then acknowledge receipt to the server:
+
+```js
+client.getReceiver(function (err, rcv) {
+  rcv.on('message', function (msg) {
+    console.log(msg);
+    rcv.complete(msg, function () {
+      console.log('completed');
+    });
+  });
+  rcv.on('errorReceived', function (err) {
+    console.warn(err);
+  });
+});
+```

--- a/node/device/transport/amqp/package.json
+++ b/node/device/transport/amqp/package.json
@@ -1,13 +1,13 @@
 {
   "name": "azure-iot-device-amqp",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "AMQP transport for Azure IoT device SDK",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-amqp-base": "1.0.0-preview.10",
-    "azure-iot-common": "1.0.0-preview.10",
-    "azure-iot-device": "1.0.0-preview.10"
+    "azure-iot-amqp-base": "1.0.0-preview.11",
+    "azure-iot-common": "1.0.0-preview.11",
+    "azure-iot-device": "1.0.0-preview.11"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/node/device/transport/amqp/readme.md
+++ b/node/device/transport/amqp/readme.md
@@ -1,0 +1,46 @@
+#azure-iot-device-amqp
+Communicate with Azure IoT Hub from any device over AMQP.
+
+[![npm version](https://badge.fury.io/js/azure-iot-device-amqp.svg)](https://badge.fury.io/js/azure-iot-device-amqp)
+
+## Install
+
+`npm install -g azure-iot-device-amqp@latest` to get the latest (pre-release) version.
+
+## Getting Started
+
+Create a device client:
+
+```js
+var clientFromConnectionString = require('azure-iot-device-amqp').clientFromConnectionString;
+var Message = require('azure-iot-device').Message;
+
+var connectionString = '[IoT Hub device connection string]';
+
+var client = clientFromConnectionString(connectionString);
+```
+
+Send an event:
+
+```js
+var msg = new Message('some data from my device');
+client.sendEvent(message, function (err) {
+  if (err) console.log(err.toString());
+});
+```
+
+Receive a message, then acknowledge receipt to the server:
+
+```js
+client.getReceiver(function (err, rcv) {
+  rcv.on('message', function (msg) {
+    console.log(msg);
+    rcv.complete(msg, function () {
+      console.log('completed');
+    });
+  });
+  rcv.on('errorReceived', function (err) {
+    console.warn(err);
+  });
+});
+```

--- a/node/device/transport/http/package.json
+++ b/node/device/transport/http/package.json
@@ -1,13 +1,13 @@
 {
   "name": "azure-iot-device-http",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "HTTP transport for Azure IoT device SDK",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-http-base": "1.0.0-preview.10",
-    "azure-iot-common": "1.0.0-preview.10",
-    "azure-iot-device": "1.0.0-preview.10",
+    "azure-iot-http-base": "1.0.0-preview.11",
+    "azure-iot-common": "1.0.0-preview.11",
+    "azure-iot-device": "1.0.0-preview.11",
     "node-crontab": "^0.0.8"
   },
   "devDependencies": {

--- a/node/device/transport/http/readme.md
+++ b/node/device/transport/http/readme.md
@@ -1,0 +1,46 @@
+#azure-iot-device-http
+Communicate with Azure IoT Hub from any device over HTTP 1.1.
+
+[![npm version](https://badge.fury.io/js/azure-iot-device-http.svg)](https://badge.fury.io/js/azure-iot-device-http)
+
+## Install
+
+`npm install -g azure-iot-device-http@latest` to get the latest (pre-release) version.
+
+## Getting Started
+
+Create a device client:
+
+```js
+var clientFromConnectionString = require('azure-iot-device-http').clientFromConnectionString;
+var Message = require('azure-iot-device').Message;
+
+var connectionString = '[IoT Hub device connection string]';
+
+var client = clientFromConnectionString(connectionString);
+```
+
+Send an event:
+
+```js
+var msg = new Message('some data from my device');
+client.sendEvent(message, function (err) {
+  if (err) console.log(err.toString());
+});
+```
+
+Receive a message, then acknowledge receipt to the server:
+
+```js
+client.getReceiver(function (err, rcv) {
+  rcv.on('message', function (msg) {
+    console.log(msg);
+    rcv.complete(msg, function () {
+      console.log('completed');
+    });
+  });
+  rcv.on('errorReceived', function (err) {
+    console.warn(err);
+  });
+});
+```

--- a/node/device/transport/mqtt/package.json
+++ b/node/device/transport/mqtt/package.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-iot-device-mqtt",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "MQTT transport for Azure IoT device SDK",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-mqtt-base": "1.0.0-preview.10",
-    "azure-iot-device": "1.0.0-preview.10"
+    "azure-iot-mqtt-base": "1.0.0-preview.11",
+    "azure-iot-device": "1.0.0-preview.11"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/node/device/transport/mqtt/readme.md
+++ b/node/device/transport/mqtt/readme.md
@@ -1,0 +1,39 @@
+#azure-iot-device-mqtt
+Communicate with Azure IoT Hub from any device over MQTT.
+
+[![npm version](https://badge.fury.io/js/azure-iot-device-mqtt.svg)](https://badge.fury.io/js/azure-iot-device-mqtt)
+
+## Install
+
+`npm install -g azure-iot-device-mqtt@latest` to get the latest (pre-release) version.
+
+## Getting Started
+
+Create a device client:
+
+```js
+var clientFromConnectionString = require('azure-iot-device-mqtt').clientFromConnectionString;
+var Message = require('azure-iot-device').Message;
+
+var connectionString = '[IoT Hub device connection string]';
+
+var client = clientFromConnectionString(connectionString);
+```
+
+Send an event:
+
+```js
+var msg = new Message('some data from my device');
+client.sendEvent(message, function (err) {
+  if (err) console.log(err.toString());
+});
+```
+
+Receive a message from IoT Hub:
+
+```js
+client.receive(function (err, msg) {
+  if (err) console.error(err);
+  else console.log(msg);
+});
+```

--- a/node/service/package.json
+++ b/node/service/package.json
@@ -1,14 +1,14 @@
 {
   "name": "azure-iothub",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "Azure IoT SDK - IoT Hub",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "main": "iothub.js",
   "dependencies": {
-    "azure-iot-amqp-base": "1.0.0-preview.10",
-    "azure-iot-http-base": "1.0.0-preview.10",
-    "azure-iot-common": "1.0.0-preview.10"
+    "azure-iot-amqp-base": "1.0.0-preview.11",
+    "azure-iot-http-base": "1.0.0-preview.11",
+    "azure-iot-common": "1.0.0-preview.11"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/node/service/samples/package.json
+++ b/node/service/samples/package.json
@@ -6,6 +6,6 @@
   "author": "Microsoft Corp.",
   "license": "MIT",
   "dependencies": {
-    "azure-iothub": "1.0.0-preview.10"
+    "azure-iothub": "1.0.0-preview.11"
   }
 }

--- a/tools/iothub-explorer/package.json
+++ b/tools/iothub-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iothub-explorer",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "Azure IoT Hub Explorer",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -8,8 +8,8 @@
   "bin": "iothub-explorer.js",
   "dependencies": {
     "amqp10": "2.1.2",
-    "azure-iot-common": "1.0.0-preview.10",
-    "azure-iothub": "1.0.0-preview.10",
+    "azure-iot-common": "1.0.0-preview.11",
+    "azure-iothub": "1.0.0-preview.11",
     "bluebird": "^3.0.1",
     "colors-tmpl": "^1.0.0",
     "nopt": "^3.0.4",

--- a/tools/iothub-explorer/readme.md
+++ b/tools/iothub-explorer/readme.md
@@ -1,0 +1,50 @@
+#iothub-explorer
+A sample CLI to manage devices using the Azure IoT Hub service SDK.
+
+[![npm version](https://badge.fury.io/js/iothub-explorer.svg)](https://badge.fury.io/js/iothub-explorer)
+
+## Install
+
+`npm install -g iothub-explorer@latest` to get the latest (pre-release) version.
+
+## Getting Started
+
+Supply your IoT Hub connection string once via `login`:
+
+```shell
+$ iothub-explorer login "HostName=<my-hub>.azure-devices.net;SharedAccessKeyName=<my-policy>;SharedAccessKey=<my-policy-key>"
+
+Session started, expires Fri Jan 15 2016 17:00:00 GMT-0800 (Pacific Standard Time)
+```
+
+Get information about an already-registered device, including the device connection string:
+
+```shell
+$ iothub-explorer get known-device --connection-string
+
+-
+  deviceId:                   known-device
+  ...
+-
+  connectionString: HostName=<my-hub>.azure-devices.net;DeviceId=known-device;SharedAccessKey=<known-device-key>
+```
+
+Register a new device, and get its connection string:
+
+```shell
+$ iothub-explorer create new-device --connection-string
+
+Created device new-device
+
+-
+  deviceId:                   new-device
+  ...
+-
+  connectionString: HostName=<my-hub>.azure-devices.net;DeviceId=new-device;SharedAccessKey=<new-device-key>
+```
+
+To find out more about all supported commands:
+
+```shell
+$ iothub-explorer help
+```


### PR DESCRIPTION
Several of the SDK's Node.js packages were missing README files, causing the packages' home pages on npmjs.org to look like this:
![no-readme](https://cloud.githubusercontent.com/assets/9042469/12411530/753ef144-be34-11e5-9062-0f8e9167b2dc.png)

I updated/added the appropriate README files and bumped package versions. After this is merged into master I'll publish the updated packages.