### PR TITLE
Update eventhubclient.js

### DIFF
--- a/tools/iothub-explorer/lib/eventhubclient.js
+++ b/tools/iothub-explorer/lib/eventhubclient.js
@@ -144,4 +144,12 @@ EventHubClient.prototype.CreateReceiver = function (consumerGroup, partitionId) 
   });
 };
 
+/**
+ * Disconnect
+ */
+EventHubClient.prototype.disconnect = function () {
+	var self = this;
+	self.amqpClient.disconnect();
+};
+
 module.exports = EventHubClient;


### PR DESCRIPTION
Add disconnect function for Node-Red deploy use.
When I deploy new flow, I need disconnect ampq connect.
Avoid duplication of information received

var EventHubClient = require('../../../node_modules/iothub-explorer/lib/eventhubclient.js');

this.on('close', function () {
ehClient.disconnect();
});