### PR TITLE
Raspberry Pi Cross Compile Example

### DIFF
--- a/c/build_all/linux/build.sh
+++ b/c/build_all/linux/build.sh
@@ -27,6 +27,7 @@ usage ()
     echo " --no-amqp                     do no build AMQP transport and samples"
     echo " --no-http                     do no build HTTP transport and samples"
     echo " --no-mqtt                     do no build MQTT transport and samples"
+    echo " --toolchain-file <file>       pass cmake a toolchain file for cross compiling"
     exit 1
 }
 
@@ -34,6 +35,7 @@ process_args ()
 {
     save_next_arg=0
     extracloptions=" "
+    toolchainfile=" "
 
     for arg in $*
     do      
@@ -42,6 +44,11 @@ process_args ()
         # save arg to pass to gcc
         extracloptions="$arg $extracloptions"
         save_next_arg=0
+      elif [ $save_next_arg == 2 ]
+      then
+        # save arg to pass as toolchain file
+        toolchainfile="$arg"
+		save_next_arg=0
       else
           case "$arg" in
               "-cl" | "--compileoption" ) save_next_arg=1;;
@@ -51,10 +58,17 @@ process_args ()
               "--no-amqp" ) build_amqp=OFF;;
               "--no-http" ) build_http=OFF;;
               "--no-mqtt" ) build_mqtt=OFF;;
+              "--toolchain-file" ) save_next_arg=2;;
               * ) usage;;
           esac
       fi
     done
+
+    if [ $toolchainfile <> " " ]
+    then
+      toolchainfile=$(readlink -f $toolchainfile)
+      toolchainfile="-DCMAKE_TOOLCHAIN_FILE=$toolchainfile"
+    fi
 }
 
 process_args $*
@@ -62,7 +76,7 @@ process_args $*
 rm -r -f ~/cmake
 mkdir ~/cmake
 pushd ~/cmake
-cmake -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Dskip_unittests:BOOL=$skip_unittests $build_root
+cmake $toolchainfile -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Dskip_unittests:BOOL=$skip_unittests $build_root
 make --jobs=$(nproc)
 ctest -C "Debug" -V
 popd

--- a/c/common/testtools/CMakeLists.txt
+++ b/c/common/testtools/CMakeLists.txt
@@ -1,6 +1,4 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-if(${use_amqp})
-  add_subdirectory(iothub_test)
-endif()
+add_subdirectory(iothub_test)

--- a/c/doc/SDK_cross_compile_example.md
+++ b/c/doc/SDK_cross_compile_example.md
@@ -1,0 +1,124 @@
+# Cross Compiling the Azure IoT Hub SDK
+## Background
+
+The SDK for the Azure IoT Hub was written to use the C99 standard in order to retain a high level of compatibility with hardware platforms that have not yet seen an official release of the SDK. This should ease the burden of porting the SDK code to those platforms.
+
+One of the challenges that might be encountered though is that the platform in question is not capable of building the code. Many such platforms may require that the executables are compiled on a host with a different chipset architecture from its own. This process of building executables on a host to target a disparate platform is known as cross compiling.
+
+## Purpose of this document
+
+This document presents an example of how to cross compile the Azure IoT Hub SDK using the make system, [cmake](https://cmake.org), that is employed by the project. In this example it will demonstrate the process of cross compiling the SDK on a Debian 64-bit system targeting a Raspberry Pi. It demonstrates how one must set up the file system and the cmake options to achieve this which should assist developers attempting to cross compile for other targets.
+
+## Procedure
+
+### Version Information
+
+The host machine is running Debian GNU/Linux 8 (jessie) amd64
+The target machine is running Raspbian GNU/Linux 8 (jessie)
+
+Note this document assumes that you are using an amd64 build of Debian on the host and will use the 64-bit version of the Raspbian toolchain. You will need to select a different target toolchain if your host is not running a 64-bit Linux operating system.
+
+Though it may be possible to use a host machine running a variant of Windows this would likely be very complex to set up and thus is not addressed in this document.
+
+### Setting up the Build Environment
+
+Open a terminal prompt on your host machine in the manner you prefer.
+
+We need to acquire the SDK source code. This is available in a GitHub repository at https://github.com/Azure/azure-iot-sdks.git. We clone this too our host machine as follows:
+```
+cd ~
+mkdir Source
+cd Source
+git clone --recursive https://github.com/Azure/azure-iot-sdks.git
+```
+Further information regarding this step, which also includes important other set up requirements, can be found at <https://github.com/Azure/azure-iot-sdks/blob/master/c/doc/devbox_setup.md>. This step is only included in this document to establish the directory structure used for the rest of the example.
+
+You might consider building the SDK for your local platform at this point simply to ensure you have all the required components.
+
+In order to cross compile for a different target the first requirement is to set up an environment containing the required toolchain, system libraries and system headers that may be required to build the code. In the instance of the Raspberry Pi this is simplified by the existence of a GitHub project that has much of that work already done for us. Change to your home directory, create a new directory for the Raspberry Pi Tools and clone the project at https://github.com/raspberrypi/tools into that directory. For example:
+```
+cd ~
+mkdir RPiTools
+cd RPiTools
+git clone https://github.com/raspberrypi/tools.git
+```
+Unfortunately, this does not give us all the files that are required to build the project. At this point you will need to copy some files from a running Raspberry Pi to your host machine. Make sure you can access your Raspberry Pi via SSH (you can enable this using [raspi-config](https://www.raspberrypi.org/documentation/configuration/raspi-config.md) and select “9. Advanced Options”. Further instructions are beyond the scope of this document). On your host’s terminal enter
+```
+cd ~/RPiTools/tools/arm-bcm2708/\\
+gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf
+rsync -rl --safe-links pi@&lt;*your Pi identifier*&gt;:/{lib,usr} .
+```
+In the above command replace &lt;*your Pi identifier*&gt; with the IP address of your Raspberry Pi. If you no longer have a user identity on your Raspberry Pi called pi, then you will need to substitute an existing user identity.
+
+This command will copy many more files to your host than you actually need but, for brevity, we copy them all. If you wish, you could optimize the sync action to exclude files that are not required.
+
+### Setting up cmake to cross compile
+
+In order to tell cmake that it is performing a cross compile we need to provide it with a toolchain file. To save us some typing and to make our whole procedure less dependent upon the current user we are going to export a value. Whilst in the same directory as above enter the following command
+```
+export RPI\_ROOT=$(pwd)
+```
+You can use *export -p* to verify RPI\_ROOT has been added to the environment.
+
+Now we need to switch to the SDK directory tree. Enter this command
+```
+cd ~/Source/azure-iot-sdks/c/build\_all/linux
+```
+Using the text editor of your choice, create a new file in this directory and call it toolchain-rpi.cmake. Into this file place the following lines
+<!--- Not really python but colorizes the comments -->
+
+```python
+INCLUDE(CMakeForceCompiler)
+
+SET(CMAKE_SYSTEM_NAME Linux)     # this one is important
+SET(CMAKE\_SYSTEM\_VERSION 1)    # this one not so much
+
+# this is the location of the amd64 toolchain targeting the Raspberry Pi
+SET(CMAKE_C_COMPILER $ENV{RPI_ROOT}/../bin/arm-linux-gnueabihf-gcc)
+
+# this is the file system root of the target
+SET(CMAKE_FIND_ROOT_PATH $ENV{RPI_ROOT})
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+```
+and save the toolchain file. Your cross compilation environment is now complete.
+
+### Building the SDK
+
+The final step in the process is to run the actual build. For this you will need to be in the Linux build directory as shown above. Enter the following commands
+```
+cd ~/Source/azure-iot-sdks/c/build_all/linux
+./build.sh –-toolchain-file toolchain-rpi.cmake –-skip-e2e-tests \
+--skip-unittests -–no-amqp –-no-mqtt -cl -D__STDC_NO_ATOMICS__ \
+-cl –-sysroot=$RPI_ROOT
+```
+This will tell cmake to build the SDK using the toolchain file toolchain-rpi.cmake, skip running all tests which is important since the executables will (probably) not run successfully on the host anyway, and exclude building the amqp and mqtt transports. The define *\_\_STDC\_NO\_ATOMICS\_\_* is required because this version of the Raspberry Pi compiler does not support *atomic\_fetch\_add* and *atomic\_fetch\_sub* so we need to tell it to use the GNU equivalents. Finally, and absolutely critical is the use of the *--sysroot* option. Without this the compiler will fail to find required headers and libraries.
+
+Note that if you need to add additional compiler flags to the build you can do so by specifying the -cl option on the build line. For example, one can use *-cl -v* or -*cl Wl,-v*.
+
+## Summary
+
+This document has demonstrated how to cross compile the Azure IoT SDK on a 64-bit Debian host targeting the Raspbian operating system.
+
+## Limitations
+
+Currently this procedure does not support cross compiling the AMQP and MQTT transports. In order to do that one would first need to cross compile the Proton library for AMQP and the Paho library for MQTT. This may be addressed at a later time.
+
+## References
+
+<https://github.com/Azure/azure-iot-sdks>
+
+<https://github.com/Azure/azure-iot-sdks/blob/master/c/doc/devbox_setup.md>
+
+<https://github.com/raspberrypi/tools>
+
+<https://cmake.org/Wiki/CMake_Cross_Compiling>
+
+https://www.raspberrypi.org
+
+<http://stackoverflow.com/questions/19162072/installing-raspberry-pi-cross-compiler> (See answer)

--- a/c/iothub_client/tests/iothubclient_http_e2etests/CMakeLists.txt
+++ b/c/iothub_client/tests/iothubclient_http_e2etests/CMakeLists.txt
@@ -4,7 +4,7 @@
 #this is CMakeLists.txt for iothubclient_http_e2etests
 cmake_minimum_required(VERSION 2.8.11)
 
-if(NOT (${use_amqp} AND ${use_http}))
+if(NOT (${use_amqp} OR ${use_http}))
 	message(FATAL_ERROR "iothubclient_http_e2etests being generated without AMQP and HTTP support")
 endif()
 


### PR DESCRIPTION
Adds the facility to provide cmake with a cross compile file in order to
build the SDK for targets other than the host.