### PR TITLE
Add note to address issue #278

### DIFF
--- a/c/doc/devbox_setup.md
+++ b/c/doc/devbox_setup.md
@@ -113,7 +113,9 @@ Use the **master** branch to ensure you fetch the latest release version.
 
 This script uses **cmake** to make a folder called "cmake" in your home directory and generates a makefile. The script then builds the solution and runs the tests.
 
-> Note: you will not be able to run the samples until you configure them with a valid IoT Hub device connection string. For more information, see [Run sample on Linux](run_sample_on_desktop_linux.md).
+> Note: Every time you run `build.sh`, it deletes and then recreates the "cmake" folder in your home directory.
+
+> Note: You will not be able to run the samples until you configure them with a valid IoT Hub device connection string. For more information, see [Run sample on Linux](run_sample_on_desktop_linux.md).
 
 <a name="windowsce"/>
 ## Set up a Windows Embedded Compact 2013 development environment


### PR DESCRIPTION
Add note to devbox_setup.md to warn that cmake folder in home directory is deleted by build.sh.
See issue #278