### PR TITLE
Fixed relative markdown links in Arduino Yun "Getting Started" Doc

### DIFF
--- a/doc/get_started/openwrt-arduino-yun-c.md
+++ b/doc/get_started/openwrt-arduino-yun-c.md
@@ -32,8 +32,8 @@ You should have the following items ready before beginning the process:
 -   Computer with a Git client installed so that you can access the azure-iot-sdks code on GitHub.
   - Arduino Yun board.
   - Ubuntu x86 machine (for cross compiling)
--   [Setup your IoT hub][lnk-setup-iot-hub]
--   [Provision your device and get its credentials][lnk-manage-iot-hub]
+-   [Setup your IoT hub](../setup_iothub.md)
+-   [Provision your device and get its credentials](../manage_iot_hub.md)
 
 <a name="Step-2-PrepareDevice"></a>
 # Step 2: Prepare your Device

--- a/doc/get_started/openwrt-arduino-yun-c.md
+++ b/doc/get_started/openwrt-arduino-yun-c.md
@@ -31,8 +31,8 @@ The following document describes the process of connecting an Arduino Yun system
 You should have the following items ready before beginning the process:
 -   Computer with a Git client installed so that you can access the azure-iot-sdks code on GitHub.
   - Arduino Yun board.
-  - Ubuntu x86 machine (for cross compiling)
--   [Setup your IoT hub](../setup_iothub.md)
+  - Ubuntu x86 machine (for cross compiling) 
+-   [Setup your IoT hub](../setup_iothub.md) 
 -   [Provision your device and get its credentials](../manage_iot_hub.md)
 
 <a name="Step-2-PrepareDevice"></a>


### PR DESCRIPTION
It looked like there were two placeholder links in the documentation. I made those relative links to the docs they looked like they should be pointing to.