### PR TITLE
Update openwrt-arduino-yun-c.md

### DIFF
--- a/doc/get_started/openwrt-arduino-yun-c.md
+++ b/doc/get_started/openwrt-arduino-yun-c.md
@@ -53,7 +53,7 @@ Install dependencies under root/sudo.
 apt-get install curl libcurl4-openssl-dev uuid-dev uuid g++ make cmake git unzip openjdk-7-jre libssl-dev libncurses-dev subversion gawk
 ```
 
-- Clone this repository ([azure-iot-sdks](https://github.com/Azure/azure-iot-sdks)) to the machine you are using.
+- Clone this repository ([azure-iot-sdks](https://github.com/Azure/azure-iot-sdks)) to the machine you are using, being sure to do a recursive clone (git clone --recursive <repo address>).
 - Navigate to the folder **c/build_all/arduino** in your local copy of the repository.
 - Run the `./setup.sh` script to install the OpenWRT SDK and prerequisites. By default, the SDK will be installed at **~/openwrt/sdk**
 - (Optional) Enter 'Y' to build the Azure IoT SDK.


### PR DESCRIPTION
Spent ages trying to figure out why build.sh was failing.  Answer was submodule links to other azure repos. 