### PR TITLE
Working servicesampledocs

### DIFF
--- a/doc/get_started/java-run-service-sample.md
+++ b/doc/get_started/java-run-service-sample.md
@@ -1,0 +1,117 @@
+# Getting started - running a Java service sample application
+
+This "Getting Started" document shows you how to build and run any of the samples contained within the Java SDLK service samples folder. 
+
+## Prerequisites
+
+Before you get started, you should:
+- [Prepare your development environment][devbox-setup]
+- [Setup your IoT Hub][setup-iothub]
+- [Register your device in IoT Hub][register-device]
+
+## Build and run the samples
+
+You can build and run the samples using Maven.
+
+To build and run the Device Manager Sample application:
+
+1. Preparing the Device Manager Sample application:
+
+	Navigate to the main sample file for Device Manager
+	It can be found at: 
+	{IoT device SDK root}\java\service\samples\device-manager-sample\src\main\java\samples\com\microsoft\azure\iot\service\sdk\SampleUtils.java
+
+	Locate the following code in the file:
+
+	```
+	public static final String iotHubConnectionString = "[sample iot hub connection string goes here]";
+    public static final String storageConnectionString = "[sample storage connection string goes here]";
+    public static final String deviceId = "[Device name goes here]";
+    public static final String exportFileLocation = "[Insert local folder here - something like C:\\foldername\\]";
+	```
+	
+    Replace "[sample iot hub connection string goes here]" with the connection information used in Device Explorer.
+	Replace "[Device name goes here]" with the name of the device you want to create, read. update or delete.
+    
+    Note: The **storageConnectionString** and **exportFileLocation** values are only used by the import and export samples.
+
+	Locate the main function in the DeviceManagerSample.java file:
+    
+    ```
+    public static void main(String[] args) throws IOException, URISyntaxException, Exception
+    ```
+    
+	Notice there are function calls implemented for each CRUD operation and they called from the main function in order.
+
+	Pick the operations you want to run, and comment out the others. Notice that the add operation requires you to provide some keys to associate with the device.
+    
+2. Building the Device Manager Sample application:
+
+    To build the Device Manager Sample application using Maven, at a command prompt navigate to the **\java\service\samples\device-manager-sample** folder. Then execute the following command and check for build errors:
+    
+    ```
+    mvn clean package
+    ```
+
+3. Running the Device Manager Sample application:
+
+	To run the Device Manager Sample application using Maven, execute the following command.
+    
+    ```
+    mvn exec:java -Dexec.mainClass="samples.com.microsoft.azure.iot.service.sdk.DeviceManagerSample"
+    ```
+
+	You can verify the result of your operation by using [Device Explorer or iothub-explorer tool][register-device].
+
+To build and run the Service Client Sample application:
+
+1. Preparing the Service Client Sample application:
+
+	Navigate to the main sample file for Service Client.
+	It can be found at: 
+	{IoT device SDK root}\java\service\samples\service-client-sample\src\main\java\samples\com\microsoft\azure\iot\service\sdk\ServiceClientSample.java
+
+	Locate the following code in the file:
+
+	```
+	private static final String connectionString = "[Connection string goes here]";
+	private static final String deviceId = "[Device name goes here]";
+	```
+    
+	Replace "[Connection string goes here]" with the connection information used in Device Explorer.
+	Replace "[Device name goes here]" with the name of the device you are using.
+
+	Locate the main function:
+    
+    ```
+	public static void main(String[] args) throws IOException, URISyntaxException, Exception
+    ```
+
+	Update the value of the local variable "commandMessage" to contain the message you want to send to the device.
+    
+2. Building the Service Client Sample application:
+
+    To build the Service Client Sample application using Maven, at a command prompt navigate to the **\java\service\samples\service-client-sample** folder. Then execute the following command and check for build errors:
+    
+    ```
+    mvn clean package
+    ```
+
+3. Running the Service Client Sample application:
+
+	To run the Service Client Sample application using Maven, execute the following command.
+    
+    ```
+    mvn exec:java -Dexec.mainClass="samples.com.microsoft.azure.iot.service.sdk.ServiceClientSample"
+    ```
+
+	You can verify the result of your operation by using [Device Explorer or iothub-explorer tool][register-device].
+
+## Documentation
+
+The documentation can be found [here](https://azure.github.io/azure-iot-sdks/java/service/api_reference/index.html).
+
+[devbox-setup]: java-devbox-setup.md
+[setup-iothub]: ../setup_iothub.md
+[register-device]: ../manage_iot_hub.md
+

--- a/doc/get_started/node-run-service-sample.md
+++ b/doc/get_started/node-run-service-sample.md
@@ -1,0 +1,66 @@
+---
+platform: debian, fedora, Linux, opensuse, raspbian, Ubuntu, windows, yocto 
+device: any
+language: javascript
+---
+
+Run a simple Node.js service sample to update the device registry
+===
+---
+
+# Table of Contents
+
+-   [Introduction](#Introduction)
+-   [Step 1: Prerequisites](#Prerequisites)
+-   [Step 2: Build and Run the Sample](#Build)
+
+<a name="Introduction"></a>
+# Introduction
+
+**About this document**
+
+This document describes how to build and run the **registry_sample.js** Node.js sample application that reads and updates the device identity registry in IoT Hub. This multi-step process includes:
+-   Configure Azure IoT Hub
+-   Build and run the sample
+
+<a name="Prerequisites"></a>
+# Step 1: Prerequisites
+
+You should have the following items ready before beginning the process:
+- Ensure that Node.js version 0.12.x or later is installed. Run `node --version` at the command line to check the version. For information about using a package manager to install Node.js on Linux, see [Installing Node.js via package manager][node-linux].
+- [Setup your IoT hub][lnk-setup-iot-hub] and retrieve your IoT Hub connection string.
+
+<a name="Build"></a>
+# Step 2: Build and run the sample
+
+- Get the following sample files from https://github.com/Azure/azure-iot-sdks/tree/master/node/service/samples
+    - **package.json**
+    - **registry_sample.js**
+
+- Place the files in a folder of your choice on your development machine.
+
+- Open the file **registry_sample.js** in a text editor.
+
+- Locate the following code in the file:
+
+    ```
+    var connectionString = '[IoT Connection String]';
+    ```
+
+- Replace `[IoT Connection String]` with the connection string for your IoT Hub. You retrieved this connection string when you set up your IoT Hub during the prerequisites step.
+
+- Open a new shell or Node.js command prompt and navigate to the folder where you placed the sample files. Run the sample application using the following commands:
+
+    ```
+    npm install
+    node registry_sample.js
+    ```
+
+- The sample application updates your device identity registry.
+
+# Debugging the samples
+[Visual Studio Code](https://code.visualstudio.com/) provides an excellent environment to write and debug Node.js code:
+- [Debugging with Visual Studio Code](../../doc/get_started/node-debug-vscode.md)
+
+[lnk-setup-iot-hub]: ../setup_iothub.md
+[node-linux]: https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager

--- a/java/service/doc/run_sample_on_java.md
+++ b/java/service/doc/run_sample_on_java.md
@@ -1,1 +1,1 @@
-**Note:** The content you are looking for is now located at: <https://github.com/Azure/azure-iot-sdks/blob/master/doc/get_started/java-run-sample.md>.
+**Note:** The content you are looking for is now located at: <https://github.com/Azure/azure-iot-sdks/blob/master/doc/get_started/java-run-service-sample.md>.


### PR DESCRIPTION
Reinstate missing doc for running Java service samples.
Add new doc describing how to run the node service sample.

See issue #328 