### PR TITLE
Made it clear sample won't run on AVR Arduinos

### DIFF
--- a/doc/get_started/arduinoide-arduino-wifi101-c.md
+++ b/doc/get_started/arduinoide-arduino-wifi101-c.md
@@ -38,6 +38,9 @@ You should have the following items ready before beginning the process:
 -   [Setup your IoT hub][lnk-setup-iot-hub]
 -   [Provision your device and get its credentials][lnk-manage-iot-hub]
 
+#### IMPORTANT NOTE
+The sample won't run on older 8-bit AVR-based Arduinos (like the UNO or Mega 2560). A modern 32-bit ARM Cortex M0+ MCU is required (e.g. Atmel’s SAMD21 MCU).
+
 <a name="Step-2-PrepareDevice"></a>
 # Step 2: Prepare your Device
 


### PR DESCRIPTION
Ref: https://github.com/Azure/azure-iot-sdks/issues/343

I think i've been a bit too harsh in the issue comments, sorry about that, you did actually list the prereqs correctly but having an ATWINC1500 breakout myself i disregarded the fact that a 32-bit ARM Cortex M0 is a must to run. This PR makes things crystal clear.