### PR TITLE
Fix variable name in EventHubReceiver.StartReceiveFromOffset()

### DIFF
--- a/tools/iothub-explorer/lib/eventhubreceiver.js
+++ b/tools/iothub-explorer/lib/eventhubreceiver.js
@@ -73,7 +73,7 @@ EventHubReceiver.prototype.StartReceiveFromOffset = function (startOffset) {
     self.amqpClient.createReceiver(self.endpoint).then(function (amqpReceiver) {
       amqpReceiver.on('message', function (message) {
         var eventData = new EventData(message.body, message.annotations.value);
-        self.emit(EventHubReceiver.MessageReceived, eventData);
+        self.emit(EventHubReceiver.EventReceived, eventData);
       });
       amqpReceiver.on('errorReceived', function (rx_err) {
         self.emit(EventHubReceiver.Error, rx_err);

--- a/tools/iothub-explorer/lib/eventhubreceiver.js
+++ b/tools/iothub-explorer/lib/eventhubreceiver.js
@@ -65,7 +65,7 @@ EventHubReceiver.prototype.StartReceive = function (startTime) {
  */
 EventHubReceiver.prototype.StartReceiveFromOffset = function (startOffset) {
   if (startOffset !== null) {
-    console.log('Listening on endpoint ' + this.endpoint + ' start offset: ' + startTime);
+    console.log('Listening on endpoint ' + this.endpoint + ' start offset: ' + startOffset);
   }
 
   var self = this;


### PR DESCRIPTION
startTime doesn't exist in StartReceiveFromOffset. Looks like it should be startOffset instead.