### PR TITLE
fix DeviceId case

### DIFF
--- a/node/device/samples/remote_monitoring.js
+++ b/node/device/samples/remote_monitoring.js
@@ -102,7 +102,7 @@ client.open(function (err, result) {
       humidity += generateRandomIncrement();
 
       var data = JSON.stringify({
-        'DeviceID': deviceId,
+        'DeviceId': deviceId,
         'Temperature': temperature,
         'Humidity': humidity,
         'ExternalTemperature': externalTemperature


### PR DESCRIPTION
This fixes issue https://github.com/Azure/azure-iot-remote-monitoring/issues/123
It happens that the Stream Analytics job for Telemetry expects the DeviceId with the lowercase last "d". But when the simulated device is working at the same time (and starts sending events before the real device) the job detects the properly cased header first and then works as expected, which masks the issue.

I only PR the changes to the node.js project because I was able to test it.
But it looks like C samples have the same problem.