### PR TITLE
Bump node device API docs link to 1.0.3

### DIFF
--- a/node/device/readme.md
+++ b/node/device/readme.md
@@ -15,7 +15,7 @@ For more information on how to use this library refer to the documents below:
 - [Setup IoT Hub](../../doc/setup_iothub.md)
 - [Provision devices](../../doc/manage_iot_hub.md)
 - [Run a node.js sample application](../../doc/get_started/node-run-sample.md)
-- [Node API reference](http://azure.github.io/azure-iot-sdks/node/api_reference/azure-iot-device/1.0.2/index.html)
+- [Node API reference](http://azure.github.io/azure-iot-sdks/node/api_reference/azure-iot-device/1.0.3/index.html)
 - [Debugging with Visual Studio Code](../../doc/get_started/node-debug-vscode.md)
 
 ## Directory structure


### PR DESCRIPTION
Link to 1.0.2 is broken