### PR TITLE
Enable python3 support

### DIFF
--- a/build/release/release_mbed.cmd
+++ b/build/release/release_mbed.cmd
@@ -10,7 +10,7 @@ call release_mbed_project.cmd ..\..\..\c\iothub_client\build\iothub_client
 call release_mbed_project.cmd ..\..\..\c\azure-uamqp-c\build
 call release_mbed_project.cmd ..\..\..\c\azure-umqtt-c\build
 call release_mbed_project.cmd ..\..\..\c\serializer\build
-call release_mbed_project.cmd ..\..\..\c\azure-c-shared-utility\c\build
+call release_mbed_project.cmd ..\..\..\c\azure-c-shared-utility\build
 call release_mbed_project.cmd ..\..\..\c\iothub_client\samples\iothub_client_sample_amqp
 call release_mbed_project.cmd ..\..\..\c\iothub_client\samples\iothub_client_sample_http
 call release_mbed_project.cmd ..\..\..\c\iothub_client\samples\iothub_client_sample_mqtt
@@ -24,10 +24,10 @@ call release_mbed_project.cmd ..\..\..\c\iothub_client\build\iothub_amqp_transpo
 call release_mbed_project.cmd ..\..\..\c\iothub_client\build\iothub_http_transport iothub_http_transport_bld
 call release_mbed_project.cmd ..\..\..\c\iothub_client\build\iothub_mqtt_transport iothub_mqtt_transport_bld
 call release_mbed_project.cmd ..\..\..\c\iothub_client\build\iothub_client iothub_client_bld
-call release_mbed_project.cmd ..\..\..\c\azure-uamqp-c\build azure_uamqp_bld
-call release_mbed_project.cmd ..\..\..\c\azure-umqtt-c\build azure_umqtt_bld
+call release_mbed_project.cmd ..\..\..\c\azure-uamqp-c\build azure_uamqp_c_bld
+call release_mbed_project.cmd ..\..\..\c\azure-umqtt-c\build azure_umqtt_c_bld
 call release_mbed_project.cmd ..\..\..\c\serializer\build serializer_bld
-call release_mbed_project.cmd ..\..\..\c\azure-c-shared-utility\c\build azureiot_common_bld
+call release_mbed_project.cmd ..\..\..\c\azure-c-shared-utility\build azure_c_shared_utility_bld
 call release_mbed_project.cmd ..\..\..\c\iothub_client\samples\iothub_client_sample_amqp iothub_client_sample_amqp_bld
 call release_mbed_project.cmd ..\..\..\c\iothub_client\samples\iothub_client_sample_http iothub_client_sample_http_bld
 call release_mbed_project.cmd ..\..\..\c\iothub_client\samples\iothub_client_sample_mqtt iothub_client_sample_mqtt_bld

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -26,6 +26,7 @@ option(skip_unittests "set skip_unittests to ON to skip unittests (default is OF
 option(compileOption_C "passes a string to the command line of the C compiler" OFF)
 option(compileOption_CXX "passes a string to the command line of the C++ compiler" OFF)
 option(build_python "builds the Python native iothub_client module" OFF)
+option(python_3 "choose between Python 2 and 3" OFF)
 option(build_javawrapper "builds the native iothub_client library for java C wrapper" OFF)
 
 

--- a/c/build_all/linux/build.sh
+++ b/c/build_all/linux/build.sh
@@ -16,6 +16,7 @@ skip_unittests=OFF
 build_python=OFF
 build_javawrapper=OFF
 run_valgrind=0
+python_3=OFF
 
 usage ()
 {
@@ -65,6 +66,7 @@ process_args ()
               "--no-http" ) build_http=OFF;;
               "--no-mqtt" ) build_mqtt=OFF;;
               "--build-python" ) build_python=ON;;
+              "--python-3" ) python_3=ON;;
               "--build-javawrapper" ) build_javawrapper=ON;;
               "--toolchain-file" ) save_next_arg=2;;
               "-rv" | "--run_valgrind" ) run_valgrind=1;;
@@ -85,7 +87,7 @@ process_args $*
 rm -r -f ~/cmake
 mkdir ~/cmake
 pushd ~/cmake
-cmake $toolchainfile -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Dskip_unittests:BOOL=$skip_unittests -Dbuild_python:BOOL=$build_python $build_root
+cmake $toolchainfile -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Dskip_unittests:BOOL=$skip_unittests -Dbuild_python:BOOL=$build_python -Dpython_3:BOOL=$python_3 $build_root
 
 CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 make --jobs=$CORES

--- a/c/iothub_client/tests/iothubtransportamqp_unittests/iothubtransportamqp_unittests.cpp
+++ b/c/iothub_client/tests/iothubtransportamqp_unittests/iothubtransportamqp_unittests.cpp
@@ -6,6 +6,7 @@
 #include <crtdbg.h>
 #endif
 
+#include <cstdint>
 #include <csignal>
 
 #include "testrunnerswitcher.h"

--- a/c/tools/mbed_build/CMakeLists.txt
+++ b/c/tools/mbed_build/CMakeLists.txt
@@ -87,11 +87,16 @@ endfunction(cloneMBEDRepository)
 
 function(updateMBEDSourceFiles)
 	set(source_file_destination ${local_repo_path})
+    set(exported_file_destination ${local_repo_path}/${mbed_project_base})
 	
 	message(STATUS "Copying target project files.")
 	foreach(file_item ${mbed_project_files})
 		file(GLOB expanded_file_item ${file_item})
 		file(COPY ${expanded_file_item} DESTINATION ${source_file_destination})
+    endforeach()
+	foreach(file_item ${mbed_exported_project_files})
+		file(GLOB expanded_file_item ${file_item})
+		file(COPY ${expanded_file_item} DESTINATION ${exported_file_destination})
 	endforeach()
 	
 endfunction(updateMBEDSourceFiles)

--- a/python/build_all/linux/build.sh
+++ b/python/build_all/linux/build.sh
@@ -11,12 +11,23 @@ cd $build_root
 [ $? -eq 0 ] || exit $?
 cd $build_root
 
-echo copy iothub_client library to samples folder
-cp ~/cmake/python/src/iothub_client.so ./python/device/samples/iothub_client.so
-echo copy iothub_client_mock library to tests folder
-cp ~/cmake/python/test/iothub_client_mock.so ./python/device/tests/iothub_client_mock.so
+if [[ $* == *--python-3* ]]; then
+    echo copy iothub_client library to py3 samples folder
+    cp ~/cmake/python/src/iothub_client.so ./python/device/samples/py3/iothub_client.so
+    echo copy iothub_client_mock library to tests folder
+    cp ~/cmake/python/test/iothub_client_mock.so ./python/device/tests/iothub_client_mock.so
+else
+    echo copy iothub_client library to samples folder
+    cp ~/cmake/python/src/iothub_client.so ./python/device/samples/iothub_client.so
+    echo copy iothub_client_mock library to tests folder
+    cp ~/cmake/python/test/iothub_client_mock.so ./python/device/tests/iothub_client_mock.so
+fi
 
 cd $build_root/python/device/tests/
-./iothub_client_ut.py
+if [[ $* == *--python-3* ]]; then
+python3 iothub_client_ut.py
+else
+python iothub_client_ut.py
+fi
 [ $? -eq 0 ] || exit $?
 cd $build_root

--- a/python/device/iothub_client_python/CMakeLists.txt
+++ b/python/device/iothub_client_python/CMakeLists.txt
@@ -22,7 +22,6 @@ if(WIN32)
 endif()
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME     OFF)
-find_package(Boost COMPONENTS python REQUIRED)
 
 if(WIN32)
     IF (NOT Boost_FOUND)
@@ -48,7 +47,16 @@ endif()
 
 
 # get python
-find_package(PythonLibs 2.7 REQUIRED)
+if (${python_3})
+    set(Python_ADDITIONAL_VERSIONS 3.4)
+    find_package(Boost COMPONENTS python-py34 REQUIRED)
+
+    find_package(PythonLibs 3 REQUIRED)
+else()
+    find_package(Boost COMPONENTS python REQUIRED)
+    
+    find_package(PythonLibs 2.7 REQUIRED)
+endif()
 include_directories(${PYTHON_INCLUDE_DIRS})
 link_directories(${PYTHON_LIBRARIES})
 

--- a/python/device/iothub_client_python/CMakeLists.txt
+++ b/python/device/iothub_client_python/CMakeLists.txt
@@ -48,10 +48,11 @@ endif()
 
 # get python
 if (${python_3})
-    set(Python_ADDITIONAL_VERSIONS 3.4)
-    find_package(Boost COMPONENTS python-py34 REQUIRED)
+    set(Python_ADDITIONAL_VERSIONS 3)
+    add_definitions(-DPY_MARJOR_VERSION=3)
+    find_package(Boost COMPONENTS python-py35 REQUIRED)
 
-    find_package(PythonLibs 3 REQUIRED)
+    find_package(PythonLibs 3.5 REQUIRED)
 else()
     find_package(Boost COMPONENTS python REQUIRED)
     

--- a/python/device/iothub_client_python/src/iothub_client_python.cpp
+++ b/python/device/iothub_client_python/src/iothub_client_python.cpp
@@ -936,7 +936,7 @@ public:
 #ifdef IS_PY3
         if (!PyLong_Check(option.ptr()))
         {
-            PyErr_SetString(PyExc_TypeError, "set_option expected type int");
+            PyErr_SetString(PyExc_TypeError, "set_option expected type long");
             boost::python::throw_error_already_set();
         }
         long value = boost::python::extract<long>(option);

--- a/python/device/iothub_client_python/src/iothub_client_python.cpp
+++ b/python/device/iothub_client_python/src/iothub_client_python.cpp
@@ -20,6 +20,10 @@
 #define IMPORT_NAME iothub_client
 #endif
 
+#if PY_MARJOR_VERSION >= 3
+#define IS_PY3
+#endif
+
 //#define SUPPORT___STR__
 
 // helper for debugging py objects
@@ -929,12 +933,21 @@ public:
         boost::python::object& option
         )
     {
+#ifdef IS_PY3
         if (!PyLong_Check(option.ptr()))
         {
             PyErr_SetString(PyExc_TypeError, "set_option expected type int");
             boost::python::throw_error_already_set();
         }
+        long value = boost::python::extract<long>(option);
+#else
+        if (!PyInt_Check(option.ptr()))
+        {
+            PyErr_SetString(PyExc_TypeError, "set_option expected type int");
+            boost::python::throw_error_already_set();
+        }
         int value = boost::python::extract<int>(option);
+#endif
         IOTHUB_CLIENT_RESULT result = IoTHubClient_SetOption(iotHubClientHandle, optionName.c_str(), &value);
         if (result != IOTHUB_CLIENT_OK)
         {

--- a/python/device/iothub_client_python/src/iothub_client_python.cpp
+++ b/python/device/iothub_client_python/src/iothub_client_python.cpp
@@ -474,7 +474,7 @@ public:
         }
         PyByteArrayObject *pyByteArray = (PyByteArrayObject *)pyObject;
         const unsigned char* byteArray = (const unsigned char*)pyByteArray->ob_bytes;
-        size_t size = (size_t)pyByteArray->ob_size;
+        size_t size = Py_SIZE(pyByteArray);
         iotHubMessageHandle = IoTHubMessage_CreateFromByteArray(byteArray, size);
         if (iotHubMessageHandle == NULL)
         {
@@ -496,7 +496,7 @@ public:
         }
         PyByteArrayObject *pyByteArray = (PyByteArrayObject *)pyObject;
         const unsigned char* byteArray = (const unsigned char*)pyByteArray->ob_bytes;
-        size_t size = (size_t)pyByteArray->ob_size;
+        size_t size = Py_SIZE(pyByteArray);
         return new IoTHubMessage(IoTHubMessage_CreateFromByteArray(byteArray, size));
     }
 
@@ -929,7 +929,7 @@ public:
         boost::python::object& option
         )
     {
-        if (!PyInt_Check(option.ptr()))
+        if (!PyLong_Check(option.ptr()))
         {
             PyErr_SetString(PyExc_TypeError, "set_option expected type int");
             boost::python::throw_error_already_set();

--- a/python/device/samples/py3/iothub_client_sample_amqp.py
+++ b/python/device/samples/py3/iothub_client_sample_amqp.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for
+# full license information.
+
+import random
+import time
+from iothub_client import *
+import inspect
+
+timeout = 241000
+minimumPollingTime = 9
+receiveContext = 0
+avgWindSpeed = 10.0
+message_count = 5
+received_count = 0
+
+# global counters
+receive_callbacks = 0
+send_callbacks = 0
+
+# transport protocol
+Protocol = IoTHubTransportProvider.AMQP
+
+# String containing Hostname, Device Id & Device Key in the format:
+# "HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>"
+connectionString = "[device connection string]"
+msgTxt = "{\"deviceId\": \"myFirstDevice\",\"windSpeed\": %.2f}"
+
+
+def receive_message_callback(message, counter):
+    global receive_callbacks
+    buffer = message.get_bytearray()
+    size = len(buffer)
+    print("Received Message [{}]:".format(counter))
+    print("    Data: <<<{}>>> & Size={}".format((buffer[:size], size)))
+    mapProperties = message.properties()
+    keyValuePair = mapProperties.get_internals()
+    print("    Properties: {}".format(keyValuePair))
+    counter += 1
+    receive_callbacks += 1
+    print("    Total calls received: {}".format(receive_callbacks))
+    return IoTHubMessageDispositionResult.ACCEPTED
+
+
+def send_confirmation_callback(message, result, userContext):
+    global send_callbacks
+    print("Confirmation[{}] received for message with result = {}".format((userContext, result)))
+    mapProperties = message.properties()
+    keyValuePair = mapProperties.get_internals()
+    print("    Properties: {}".format(keyValuePair))
+    send_callbacks += 1
+    print("    Total calls confirmed: {}".format(send_callbacks))
+
+
+def iothub_client_init():
+    # prepare iothub client
+    iotHubClient = IoTHubClient(connectionString, Protocol)
+    iotHubClient.set_message_callback(receive_message_callback, receiveContext)
+    return iotHubClient
+
+
+def print_last_message_time(iotHubClient):
+    try:
+        print("Actual time : {}".format(time.localtime()))
+        lastMessage = iotHubClient.get_last_message_receive_time()
+        print("Last Message: {}".format(time.localtime(lastMessage)))
+    except Exception as e:
+        if e.result == IoTHubClientResult.INDEFINITE_TIME:
+            print("No message received")
+        else:
+            print(e)
+
+
+def iothub_client_sample_run():
+
+    try:
+
+        iotHubClient = iothub_client_init()
+
+        while True:
+            # send a few messages every minute
+            print("IoTHubClient sending {} messages".format(message_count))
+
+            for i in range(message_count):
+                msgTxtFormatted = msgTxt.format(
+                    avgWindSpeed + (random.random() * 4 + 2))
+                message = IoTHubMessage(bytearray(msgTxtFormatted, 'utf8'))
+                propMap = message.properties()
+                propText = "PropMsg_{}".format(i)
+                propMap.add("Property", propText)
+                iotHubClient.send_event_async(
+                    message, send_confirmation_callback, i)
+                print("IoTHubClient.send_event_async accepted message [{}] for transmission to IoT Hub.".format(i))
+
+            # Wait for Commands or exit
+            print("IoTHubClient waiting for commands, press Ctrl-C to exit")
+
+            n = 0
+            while n < 6:
+                status = iotHubClient.get_send_status()
+                print("Send status: {}".format(status))
+                time.sleep(10)
+                n += 1
+
+    except Exception as e:
+        print("exception type: {}".format(type(e)))
+        # print(inspect.getmembers(e))
+        print("Unexpected error {} from IoTHub".format(e))
+        return
+    except KeyboardInterrupt:
+        print("IoTHubClient sample stopped")
+
+    print_last_message_time(iotHubClient)
+
+print("Starting the IoTHubClient sample using protocol {}...".format(Protocol))
+
+iothub_client_sample_run()

--- a/python/device/tests/iothub_client_ut.py
+++ b/python/device/tests/iothub_client_ut.py
@@ -318,7 +318,7 @@ class TestClassDefinitions(unittest.TestCase):
         message = IoTHubMessage(messageString)
         self.assertIsInstance(message, IoTHubMessage)
         # get_bytearray
-        message = IoTHubMessage(bytearray(messageString))
+        message = IoTHubMessage(bytearray(messageString, 'utf8'))
         self.assertIsInstance(message, IoTHubMessage)
         with self.assertRaises(AttributeError):
             message.GetByteArray()
@@ -329,7 +329,7 @@ class TestClassDefinitions(unittest.TestCase):
         with self.assertRaises(Exception):
             message.get_bytearray(["key", "value"])
         result = message.get_bytearray()
-        self.assertEqual(result, "myMessage")
+        self.assertEqual(result, b"myMessage")
         # get_string
         message = IoTHubMessage(messageString)
         self.assertIsInstance(message, IoTHubMessage)
@@ -355,7 +355,7 @@ class TestClassDefinitions(unittest.TestCase):
         message = IoTHubMessage(messageString)
         result = message.get_content_type()
         self.assertEqual(result, IoTHubMessageContent.STRING)
-        message = IoTHubMessage(bytearray(messageString))
+        message = IoTHubMessage(bytearray(messageString, 'utf8'))
         result = message.get_content_type()
         self.assertEqual(result, IoTHubMessageContent.BYTEARRAY)
         # properties


### PR DESCRIPTION
Following from #427 added an option to use python3 to be called with `./build.sh --python-3` leaving default as building with python2 as before.

A few small changes in the iothub_client_python.cpp file due to members not available in the python3 c interface. 
* Comparing the source of `Py_SIZE` macro between python2 and python3 seems to result in the same output as `ob_size` wasn't available in py3
* Also `PyLong_Check` available in both python3 and python2 whereas `PyInt_Check` wasn't available in python3.