### PR TITLE
Spelling mistake in py_major_version

### DIFF
--- a/python/device/iothub_client_python/src/iothub_client_python.cpp
+++ b/python/device/iothub_client_python/src/iothub_client_python.cpp
@@ -20,7 +20,7 @@
 #define IMPORT_NAME iothub_client
 #endif
 
-#if PY_MARJOR_VERSION >= 3
+#if PY_MAJOR_VERSION >= 3
 #define IS_PY3
 #endif
 


### PR DESCRIPTION
Sorry @mregen our previous discussions on why `PY_MAJOR_VERSION` I have found to be due to a spelling mistake on my part.