### PR TITLE
Make DeviceClient implement Closeable

### DIFF
--- a/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/DeviceClient.java
+++ b/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/DeviceClient.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.iothub.transport.IotHubReceiveTask;
 import com.microsoft.azure.iothub.transport.IotHubSendTask;
 import com.microsoft.azure.iothub.transport.IotHubTransport;
 import com.microsoft.azure.iothub.transport.mqtt.MqttTransport;
+import java.io.Closeable;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -39,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * </p>
  * The client supports HTTPS 1.1 and AMQPS 1.0 transports.
  */
-public final class DeviceClient
+public final class DeviceClient implements Closeable
 {
     /** The state of the IoT Hub client's connection with the IoT Hub. */
     protected enum IotHubClientState

--- a/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/IotHubTransport.java
+++ b/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/IotHubTransport.java
@@ -5,12 +5,12 @@ package com.microsoft.azure.iothub.transport;
 
 import com.microsoft.azure.iothub.IotHubEventCallback;
 import com.microsoft.azure.iothub.Message;
+import java.io.Closeable;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 
 /** An interface for an IoT Hub transport. */
-public interface IotHubTransport
+public interface IotHubTransport extends Closeable
 {
     /**
      * Establishes a communication channel with an IoT Hub. If a channel is


### PR DESCRIPTION
The idea behind this is that DeviceClient should be usable in try-with-resources blocks. Currently the sample code leaks connections.