### PR TITLE
Added AmqpWs support for service client

### DIFF
--- a/node/service/iothub.js
+++ b/node/service/iothub.js
@@ -16,5 +16,7 @@ module.exports = {
   Device: require('./lib/device.js'),
   Http: require('./lib/registry_http.js'),
   Registry: require('./lib/registry.js'),
-  SharedAccessSignature: require('./lib/shared_access_signature.js')
+  SharedAccessSignature: require('./lib/shared_access_signature.js'),
+  Amqp: require('./lib/amqp.js'),
+  AmqpWs: require('./lib/amqp-ws.js'),
 };

--- a/node/service/lib/amqp-ws.js
+++ b/node/service/lib/amqp-ws.js
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var util = require('util');
+var Base = require('azure-iot-amqp-base').Amqp;
+var Amqp = require('./amqp.js');
+var PackageJson = require('../package.json');
+
+/**
+ * @class       module:azure-iothub.AmqpWs
+ * @classdesc   Constructs an {@linkcode Amqp} object that can be used in an application
+ *              to connect to IoT Hub instance, using the AMQP protocol over secure websockets.
+ *              This class overloads the constructor of the base {@link module:azure-iothub--amqp:Amqp} class from the AMQP transport, and inherits all methods from it.
+ */
+/*Codes_SRS_NODE_IOTHUB_SERVICE_AMQP_16_001: [The AmqpWs constructor shall accept a config object with those 4 properties:
+host – (string) the fully-qualified DNS hostname of an IoT Hub
+hubName - (string) the name of the IoT Hub instance (without suffix such as .azure-devices.net).
+keyName – (string) the name of a key that can be used to communicate with the IoT Hub instance
+sharedAccessSignature – (string) the key associated with the key name.] */
+function AmqpWs(config) {
+  this._config = config;
+  this._initialize();
+}
+
+util.inherits(AmqpWs, Amqp);
+
+AmqpWs.prototype._initialize = function () {
+    
+  var uri = 'wss://';
+  uri += encodeURIComponent(this._config.keyName) +
+         '%40sas.root.' +
+         this._config.hubName +
+         ':' +
+         encodeURIComponent(this._config.sharedAccessSignature) +
+         '@' +
+         this._config.host + ':443/$iothub/websocket';;
+ 
+  this._amqp = new Base(uri, false, 'azure-iot-device/' + PackageJson.version);
+};
+
+module.exports = AmqpWs;

--- a/node/service/lib/client.js
+++ b/node/service/lib/client.js
@@ -39,16 +39,23 @@ function Client(transport) {
  * @description       Creates an IoT Hub service client from the given
  *                    connection string using the default transport
  *                    ({@link module:azure-iothub~Transport|Transport}).
- * @param {String}    value   A connection string which encapsulates "service
- *                            connect" permissions on an IoT hub.
+ * 
+ * @param {String}    connStr       A connection string which encapsulates "device
+ *                                  connect" permissions on an IoT hub.
+ * @param {Function}  Transport     A transport constructor.
+ * 
  * @returns {module:azure-iothub.Client}
 */
-Client.fromConnectionString = function fromConnectionString(value) {
-  /*Codes_SRS_NODE_IOTHUB_CLIENT_05_002: [The fromConnectionString method shall throw ReferenceError if the value argument is falsy.]*/
-  if (!value) throw new ReferenceError('value is \'' + value + '\'');
-
+Client.fromConnectionString = function fromConnectionString(connStr, Transport) {
+  /*Codes_SRS_NODE_IOTHUB_CLIENT_05_002: [The fromConnectionString method shall throw ReferenceError if the connStr argument is falsy.]*/
+  if (!connStr) throw new ReferenceError('connStr is \'' + connStr + '\'');
+  
+  if(!Transport){
+      Transport = DefaultTransport;
+  }
+  
   /*Codes_SRS_NODE_IOTHUB_CLIENT_05_003: [Otherwise, it shall derive and transform the needed parts from the connection string in order to create a new instance of the default transport (azure-iothub.Transport).]*/
-  var cn = ConnectionString.parse(value);
+  var cn = ConnectionString.parse(connStr);
   var sas = SharedAccessSignature.create(cn.HostName, cn.SharedAccessKeyName, cn.SharedAccessKey, anHourFromNow());
 
   var config = {
@@ -57,9 +64,9 @@ Client.fromConnectionString = function fromConnectionString(value) {
     keyName: cn.SharedAccessKeyName,
     sharedAccessSignature: sas.toString()
   };
-
+  
   /*Codes_SRS_NODE_IOTHUB_CLIENT_05_004: [The fromConnectionString method shall return a new instance of the Client object, as by a call to new Client(transport).]*/
-  return new Client(new DefaultTransport(config));
+  return new Client(new Transport(config));
 };
 
 /**
@@ -67,16 +74,22 @@ Client.fromConnectionString = function fromConnectionString(value) {
  * @description       Creates an IoT Hub service client from the given
  *                    shared access signature using the default transport
  *                    ({@link module:azure-iothub~Transport|Transport}).
- * @param {String}    value   A shared access signature which encapsulates
+ * 
+ * @param {String}    sharedAccessSignature   A shared access signature which encapsulates
  *                            "service connect" permissions on an IoT hub.
+ * @param {Function}  Transport     A transport constructor.
+ * 
  * @returns {module:azure-iothub.Client}
  */
-Client.fromSharedAccessSignature = function fromSharedAccessSignature(value) {
-  /*Codes_SRS_NODE_IOTHUB_CLIENT_05_005: [The fromSharedAccessSignature method shall throw ReferenceError if the value argument is falsy.]*/
-  if (!value) throw new ReferenceError('value is \'' + value + '\'');
-
+Client.fromSharedAccessSignature = function fromSharedAccessSignature(sharedAccessSignature, Transport) {
+  /*Codes_SRS_NODE_IOTHUB_CLIENT_05_005: [The fromSharedAccessSignature method shall throw ReferenceError if the sharedAccessSignature argument is falsy.]*/
+  if (!sharedAccessSignature) throw new ReferenceError('sharedAccessSignature is \'' + sharedAccessSignature + '\'');
+  
+  if(!Transport){
+      Transport = DefaultTransport;
+  }  
   /*Codes_SRS_NODE_IOTHUB_CLIENT_05_006: [Otherwise, it shall derive and transform the needed parts from the shared access signature in order to create a new instance of the default transport (azure-iothub.Transport).]*/
-  var sas = SharedAccessSignature.parse(value);
+  var sas = SharedAccessSignature.parse(sharedAccessSignature);
   var decodedUri = decodeURIComponent(sas.sr);
 
   var config = {
@@ -87,7 +100,7 @@ Client.fromSharedAccessSignature = function fromSharedAccessSignature(value) {
   };
 
   /*Codes_SRS_NODE_IOTHUB_CLIENT_05_007: [The fromSharedAccessSignature method shall return a new instance of the Client object, as by a call to new Client(transport).]*/
-  return new Client(new DefaultTransport(config));
+  return new Client(new Transport(config));
 };
 
 /**


### PR DESCRIPTION
Added support for AmqpWs to the node.js service client after suggestion from @pierreca. 

**Added**: node/service/lib/amqp-ws.js
_amqp-ws transport class that inherits from the amqp class_

**Updated**: node/service/iothub.js
_Added exports for Amqp and AmqpWs_

**Updated**: node/service/lib/client.js
_Updated the fromConnectionString and fromSharedAccessSignature operations as:_

- Changed the 'value' parameter name to connStr and sharedAccessSignature
- Added Transport parameter
- Added setting Transport to DefaultTransport if not set
- Updated comments

**Left to do**
_No unit tests has been added or updated_