### PR TITLE
Add an option to generate a SAS Token for a device

### DIFF
--- a/tools/iothub-explorer/iothub-explorer.js
+++ b/tools/iothub-explorer/iothub-explorer.js
@@ -279,8 +279,9 @@ else if (command === 'sas-token') {
       serviceError(err);
     else {
       var key = device.authentication.SymmetricKey.primaryKey;
-      var expiry = arg2 ? Math.ceil((Date.now() / 1000) + (3600 * arg2)) : anHourFromNow();
-      console.log('SAS Token for device ' + arg1 + ' with expiry ' + (arg2 ? arg2 : 'one') + ' hour(s) from now:');
+      var expiry = endTime();
+      if (!parsed.raw)
+        console.log(colorsTmpl('{green}SAS Token for device ' + arg1 + ' with expiry ' + (parsed.duration ? parsed.duration : '3600') + ' seconds from now:{/green}'));
       var sas = DeviceSAS.create(hostname, arg1, key, expiry);
       console.log(sas.toString());
     }
@@ -411,9 +412,9 @@ function usage() {
     '    {grey}Sends a cloud-to-device message to the given device, optionally with acknowledgment of receipt{/grey}',
     '  {green}iothub-explorer{/green} {white}[<connection-string>] receive [--messages=n]{/white}',
     '    {grey}Receives feedback about the delivery of cloud-to-device messages; optionally exits after receiving {white}n{/white} messages.{/grey}',
-    '  {green}iothub-explorer{/green} {white}[<connection-string>] sas-token <device-id> [expiry]{/white}',
-    '    {grey}Generates a SAS Token for the given device',
-    '    Specify expiry in hours, default expiration is one hour.{/grey}',
+    '  {green}iothub-explorer{/green} {white}[<connection-string>] sas-token <device-id> [--duration=<num-seconds>]{/white}',
+    '    {grey}Generates a SAS Token for the given device with an expiry time <num-seconds> from now',
+    '    Default duration is 3600 (one hour).{/grey}',
     '  {green}iothub-explorer{/green} {white}help{/white}',
     '    {grey}Displays this help message.{/grey}',
     '',

--- a/tools/iothub-explorer/package.json
+++ b/tools/iothub-explorer/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "amqp10": "2.1.2",
     "azure-iot-common": "1.0.6",
-    "azure-iot-device": "^1.0.6",
+    "azure-iot-device": "1.0.6",
     "azure-iothub": "1.0.8",
     "bluebird": "^3.0.1",
     "colors-tmpl": "^1.0.0",

--- a/tools/iothub-explorer/package.json
+++ b/tools/iothub-explorer/package.json
@@ -8,8 +8,9 @@
   "bin": "iothub-explorer.js",
   "dependencies": {
     "amqp10": "2.1.2",
-    "azure-iot-common": "1.0.0-preview.11",
-    "azure-iothub": "1.0.0-preview.11",
+    "azure-iot-common": "1.0.6",
+    "azure-iot-device": "^1.0.6",
+    "azure-iothub": "1.0.8",
     "bluebird": "^3.0.1",
     "colors-tmpl": "^1.0.0",
     "nopt": "^3.0.4",


### PR DESCRIPTION
Hi there, I was looking for a way to generate a SAS Token from the command line the other day and couldn't find one, so I added a small option to the iothub-explorer tool.