### PR TITLE
Update Export/Import registry methods to protected

### DIFF
--- a/csharp/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/csharp/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -342,22 +342,22 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Copies registered device data to a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName);
+        protected abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName);
 
         /// <summary>
         /// Copies registered device data to a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
+        protected abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Imports registered device data from a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName);
+        protected abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName);
 
         /// <summary>
         /// Imports registered device data from a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
+        protected abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates a new bulk job to export device registrations to the container specified by the provided URI.


### PR DESCRIPTION
Current access specifier of internal abstract makes this class impossible to mock/stub/fake which is preventing to write unit test for the class which is using RegistryManager.