### PR TITLE
Krish gh dev

### DIFF
--- a/csharp/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/csharp/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -431,12 +431,12 @@ namespace Microsoft.Azure.Devices
 
         }
 
-        internal override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName)
+        protected override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName)
         {
             return this.ExportRegistryAsync(storageAccountConnectionString, containerName, CancellationToken.None);
         }
 
-        internal override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
+        protected override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
         {
             this.EnsureInstanceNotClosed();
 
@@ -457,12 +457,12 @@ namespace Microsoft.Azure.Devices
                 cancellationToken);
         }
 
-        internal override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName)
+        protected override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName)
         {
             return this.ImportRegistryAsync(storageAccountConnectionString, containerName, CancellationToken.None);
         }
 
-        internal override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
+        protected override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
         {
             this.EnsureInstanceNotClosed();
 

--- a/csharp/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/csharp/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -431,12 +431,12 @@ namespace Microsoft.Azure.Devices
 
         }
 
-        protected override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName)
+        internal override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName)
         {
             return this.ExportRegistryAsync(storageAccountConnectionString, containerName, CancellationToken.None);
         }
 
-        protected override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
+        internal override Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
         {
             this.EnsureInstanceNotClosed();
 
@@ -457,12 +457,12 @@ namespace Microsoft.Azure.Devices
                 cancellationToken);
         }
 
-        protected override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName)
+        internal override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName)
         {
             return this.ImportRegistryAsync(storageAccountConnectionString, containerName, CancellationToken.None);
         }
 
-        protected override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
+        internal override Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken)
         {
             this.EnsureInstanceNotClosed();
 

--- a/csharp/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/csharp/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -342,22 +342,22 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Copies registered device data to a set of blobs in a specific container in a storage account. 
         /// </summary>
-        protected abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName);
+        internal abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName);
 
         /// <summary>
         /// Copies registered device data to a set of blobs in a specific container in a storage account. 
         /// </summary>
-        protected abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
+        internal abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Imports registered device data from a set of blobs in a specific container in a storage account. 
         /// </summary>
-        protected abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName);
+        internal abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName);
 
         /// <summary>
         /// Imports registered device data from a set of blobs in a specific container in a storage account. 
         /// </summary>
-        protected abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
+        internal abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates a new bulk job to export device registrations to the container specified by the provided URI.

--- a/csharp/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/csharp/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -342,22 +342,22 @@ namespace Microsoft.Azure.Devices
         /// <summary>
         /// Copies registered device data to a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName);
+        protected abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName);
 
         /// <summary>
         /// Copies registered device data to a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
+        protected abstract Task ExportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Imports registered device data from a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName);
+        protected abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName);
 
         /// <summary>
         /// Imports registered device data from a set of blobs in a specific container in a storage account. 
         /// </summary>
-        internal abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
+        protected abstract Task ImportRegistryAsync(string storageAccountConnectionString, string containerName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates a new bulk job to export device registrations to the container specified by the provided URI.


### PR DESCRIPTION
Update Export/Import registry methods to protected

Current access specifier of internal abstract makes this class impossible to mock/stub/fake which is preventing to write unit test for the class which is using RegistryManager.