### PR TITLE
Print raw error msg if requested + Print session filename

### DIFF
--- a/tools/iothub-explorer/iothub-explorer.js
+++ b/tools/iothub-explorer/iothub-explorer.js
@@ -20,6 +20,7 @@ var ConnectionString = require('azure-iothub').ConnectionString;
 var SharedAccessSignature = require('azure-iothub').SharedAccessSignature;
 var anHourFromNow = require('azure-iot-common').anHourFromNow;
 var DeviceSAS = require('azure-iot-device').SharedAccessSignature;
+var Util = require('util');
 
 function Count(val) {
   this.val = +val;
@@ -95,6 +96,7 @@ if (!connString) {
   var loc = configLoc();
   try {
     sas = fs.readFileSync(loc.dir + '/' + loc.file, 'utf8');
+    console.log(colorsTmpl('\n{green}Using session file: '+loc.dir + '/' + loc.file + '{/green}'));
   }
   catch (err) { // swallow file not found exception
     if (err.code !== 'ENOENT') throw err;
@@ -320,6 +322,9 @@ function serviceError(err) {
       message = message.slice('Error:'.length);
     }
     console.log(colorsTmpl('\n{bold}{red}Error{/red}{/bold}' + message));
+  }
+  else {
+    console.log(colorsTmpl('\n{bold}{red}Raw error message: ' + Util.inspect(err) + '{/red}{/bold}'));
   }
   process.exit(1);
 }

--- a/tools/iothub-explorer/package.json
+++ b/tools/iothub-explorer/package.json
@@ -15,7 +15,8 @@
     "colors-tmpl": "^1.0.0",
     "nopt": "^3.0.4",
     "prettyjson": "^1.1.3",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1",
+    "util": "0.10.3"
   },
   "devDependencies": {
     "jshint": "^2.8.0"


### PR DESCRIPTION
- Fix: When using '--raw' then print the raw error message (using Util to handle circular references in the error object)
- Improve: Print name of the file where the auth session is stored, so that a user is aware of credentials stored locally (e.g. to remove them if required)
