### PR TITLE
C# asynchronous code should call ConfigureAwait(false) to avoid deadlocking especially in ASP.NET

### DIFF
--- a/csharp/device/Microsoft.Azure.Devices.Client/Common/Amqp/ClientWebSocketTransport.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Common/Amqp/ClientWebSocketTransport.cs
@@ -79,14 +79,14 @@ namespace Microsoft.Azure.Amqp.Transport
                 if (args.Buffer != null)
                 {
                     var arraySegment = new ArraySegment<byte>(args.Buffer, args.Offset, args.Count);
-                    await this.webSocket.SendAsync(arraySegment, WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token);
+                    await this.webSocket.SendAsync(arraySegment, WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token).ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (ByteBuffer byteBuffer in args.ByteBufferList)
                     {
                         await this.webSocket.SendAsync(new ArraySegment<byte>(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length),
-                            WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token);
+                            WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token).ConfigureAwait(false);
                     }
                 }
 
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Amqp.Transport
             try
             {
                 WebSocketReceiveResult receiveResult = await this.webSocket.ReceiveAsync(
-                    new ArraySegment<byte>(args.Buffer, args.Offset, args.Count), CancellationToken.None);
+                    new ArraySegment<byte>(args.Buffer, args.Offset, args.Count), CancellationToken.None).ConfigureAwait(false);
 
                 succeeded = true;
                 return receiveResult.Count;
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
                 using (var cancellationTokenSource = new CancellationTokenSource(timeout))
                 {
-                    await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token);
+                    await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
                 }
             }
             catch (Exception e)

--- a/csharp/device/Microsoft.Azure.Devices.Client/Common/Amqp/LegacyClientWebSocketTransport.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Common/Amqp/LegacyClientWebSocketTransport.cs
@@ -84,13 +84,13 @@ namespace Microsoft.Azure.Devices.Client
             {
                 if (args.Buffer != null)
                 {
-                    await this.webSocket.SendAsync(args.Buffer, args.Offset, args.Count, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout);
+                    await this.webSocket.SendAsync(args.Buffer, args.Offset, args.Count, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout).ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (ByteBuffer byteBuffer in args.ByteBufferList)
                     {
-                        await this.webSocket.SendAsync(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout);
+                        await this.webSocket.SendAsync(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout).ConfigureAwait(false);
                     }
                 }
 
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Devices.Client
             bool succeeded = false;
             try
             {
-                int numBytes = await this.webSocket.ReceiveAsync(this.asyncReadBuffer, this.asyncReadBufferOffset, this.asyncReadBufferSize, this.operationTimeout);
+                int numBytes = await this.webSocket.ReceiveAsync(this.asyncReadBuffer, this.asyncReadBufferOffset, this.asyncReadBufferSize, this.operationTimeout).ConfigureAwait(false);
 
                 succeeded = true;
                 return numBytes;
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             try
             {
-               await this.webSocket.CloseAsync();
+               await this.webSocket.CloseAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/csharp/device/Microsoft.Azure.Devices.Client/Common/Exceptions/ExceptionHandlingHelper.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Common/Exceptions/ExceptionHandlingHelper.cs
@@ -15,16 +15,16 @@ namespace Microsoft.Azure.Devices.Client.Exceptions
         {
             var mappings = new Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>();
 
-            mappings.Add(HttpStatusCode.NoContent, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.NotFound, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.Conflict, async (response) => new DeviceAlreadyExistsException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.BadRequest, async (response) => new ArgumentException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.Unauthorized, async (response) => new UnauthorizedException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.Forbidden, async (response) => new QuotaExceededException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.PreconditionFailed, async (response) => new DeviceMessageLockLostException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.RequestEntityTooLarge, async (response) => new MessageTooLargeException(await GetExceptionMessageAsync(response))); ;
-            mappings.Add(HttpStatusCode.InternalServerError, async (response) => new ServerErrorException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.ServiceUnavailable, async (response) => new ServerBusyException(await GetExceptionMessageAsync(response)));
+            mappings.Add(HttpStatusCode.NoContent, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.NotFound, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.Conflict, async (response) => new DeviceAlreadyExistsException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.BadRequest, async (response) => new ArgumentException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.Unauthorized, async (response) => new UnauthorizedException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.Forbidden, async (response) => new QuotaExceededException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.PreconditionFailed, async (response) => new DeviceMessageLockLostException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.RequestEntityTooLarge, async (response) => new MessageTooLargeException(await GetExceptionMessageAsync(response).ConfigureAwait(false))); ;
+            mappings.Add(HttpStatusCode.InternalServerError, async (response) => new ServerErrorException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.ServiceUnavailable, async (response) => new ServerBusyException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
 
             return mappings;
         }

--- a/csharp/device/Microsoft.Azure.Devices.Client/Common/FaultTolerantAmqpObject.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Common/FaultTolerantAmqpObject.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Client
 
         protected override async Task<T> OnCreateAsync(TimeSpan timeout)
         {
-            T amqpObject = await this.createObjectAsync(timeout);
+            T amqpObject = await this.createObjectAsync(timeout).ConfigureAwait(false);
             amqpObject.SafeAddClosed((s, e) => this.Invalidate(amqpObject));
 
             return amqpObject;

--- a/csharp/device/Microsoft.Azure.Devices.Client/Common/Singleton.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Common/Singleton.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Client
                 
                 if (this.TryGet(out tcs))
                 {
-                    return await tcs.Task;
+                    return await tcs.Task.ConfigureAwait(false);
                 }
 
                 tcs = new TaskCompletionSource<TValue>();
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             try
             {
-                TValue value = await OnCreateAsync(timeout);
+                TValue value = await OnCreateAsync(timeout).ConfigureAwait(false);
                 tcs.SetResult(value);
 
                 if (this.disposed)

--- a/csharp/device/Microsoft.Azure.Devices.Client/Common/TaskHelpers.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Common/TaskHelpers.cs
@@ -356,16 +356,16 @@ namespace Microsoft.Azure.Devices.Client
 
             if (task.IsCompleted || (timeout == Timeout.InfiniteTimeSpan && token == CancellationToken.None))
             {
-                await task;
+                await task.ConfigureAwait(false);
                 return;
             }
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
-                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)).ConfigureAwait(false))
                 {
                     cts.Cancel();
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
             }
         }
@@ -384,16 +384,16 @@ namespace Microsoft.Azure.Devices.Client
 
             if (task.IsCompleted || (timeout == Timeout.InfiniteTimeSpan && token == CancellationToken.None))
             {
-                await task;
+                await task.ConfigureAwait(false);
                 return;
             }
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
-                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)).ConfigureAwait(false))
                 {
                     cts.Cancel();
-                    await task;
+                    await task.ConfigureAwait(false);
                     return;
                 }
             }
@@ -415,15 +415,15 @@ namespace Microsoft.Azure.Devices.Client
 
             if (task.IsCompleted || (timeout == Timeout.InfiniteTimeSpan && token == CancellationToken.None))
             {
-                return await task;
+                return await task.ConfigureAwait(false);
             }
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
-                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)).ConfigureAwait(false))
                 {
                     cts.Cancel();
-                    return await task;
+                    return await task.ConfigureAwait(false);
                 }
             }
 

--- a/csharp/device/Microsoft.Azure.Devices.Client/IotHubClientWebSocket.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/IotHubClientWebSocket.cs
@@ -156,13 +156,13 @@ namespace Microsoft.Azure.Devices.Client
             {
                 // Connect without proxy
                 this.TcpClient = new TcpClient();
-                await this.TcpClient.ConnectAsync(host, port);
+                await this.TcpClient.ConnectAsync(host, port).ConfigureAwait(false);
 
                 if (string.Equals(WebSocketConstants.Scheme, scheme, StringComparison.OrdinalIgnoreCase))
                 {
                     // In the real world, web-socket will happen over HTTPS
                     var sslStream = new SslStream(this.TcpClient.GetStream(), false, IotHubConnection.OnRemoteCertificateValidation);
-                    await sslStream.AuthenticateAsClientAsync(host);
+                    await sslStream.AuthenticateAsClientAsync(host).ConfigureAwait(false);
                     this.WebSocketStream = sslStream;
                 }
                 else
@@ -176,14 +176,14 @@ namespace Microsoft.Azure.Devices.Client
                 this.TcpClient.Client.SendTimeout = GetSocketTimeoutInMilliSeconds(timeout);
 
                 // Send WebSocket Upgrade request
-                await this.WebSocketStream.WriteAsync(upgradeRequestBytes, 0, upgradeRequestBytes.Length);
+                await this.WebSocketStream.WriteAsync(upgradeRequestBytes, 0, upgradeRequestBytes.Length).ConfigureAwait(false);
 
                 // receive WebSocket Upgrade response
                 var responseBuffer = new byte[8 * 1024];
 
                 var upgradeResponse = new HttpResponse(this.TcpClient, this.WebSocketStream, responseBuffer);
 
-                await upgradeResponse.ReadAsync(timeout);
+                await upgradeResponse.ReadAsync(timeout).ConfigureAwait(false);
 
                 if (upgradeResponse.StatusCode != HttpStatusCode.SwitchingProtocols)
                 {
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.Client
                     totalBytesRead = 0;
                     do
                     {
-                        bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead);
+                        bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead).ConfigureAwait(false);
                         if (bytesRead == 0)
                         {
                             throw new IOException(FramingPrematureEOF, new InvalidDataException("IotHubClientWebSocket was expecting more bytes"));
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.Client
                         // Encountered a close frame or error in parsing frame from server. Close connection
                         var closeHeader = PrepareWebSocketHeader(0, WebSocketMessageType.Close);
 
-                        await this.WebSocketStream.WriteAsync(closeHeader, 0, closeHeader.Length);
+                        await this.WebSocketStream.WriteAsync(closeHeader, 0, closeHeader.Length).ConfigureAwait(false);
 
                         this.State = WebSocketState.Closed;
                         this.WebSocketStream?.Close();
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Client
                         var tempBuffer = new byte[payloadLength];
                         while (totalBytesRead < payloadLength)
                         {
-                            bytesRead = await this.WebSocketStream.ReadAsync(tempBuffer, totalBytesRead, payloadLength - totalBytesRead);
+                            bytesRead = await this.WebSocketStream.ReadAsync(tempBuffer, totalBytesRead, payloadLength - totalBytesRead).ConfigureAwait(false);
                             if (bytesRead == 0)
                             {
                                 throw new IOException(FramingPrematureEOF, new InvalidDataException("IotHubClientWebSocket was expecting more bytes"));
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.Devices.Client
                 {
                     while (totalBytesRead < payloadLength)
                     {
-                        bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, payloadLength - totalBytesRead);
+                        bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, payloadLength - totalBytesRead).ConfigureAwait(false);
 
                         if (bytesRead == 0)
                         {
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Devices.Client
                             // read payload length (< 64K)
                             do
                             {
-                                bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead);
+                                bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead).ConfigureAwait(false);
 
                                 if (bytesRead == 0)
                                 {
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.Client
                             {
                                 while (totalBytesRead < extendedPayloadLength)
                                 {
-                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, extendedPayloadLength - totalBytesRead);
+                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, extendedPayloadLength - totalBytesRead).ConfigureAwait(false);
 
                                     if (bytesRead == 0)
                                     {
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Devices.Client
                             var payloadLengthBuffer = new byte[8];
                             do
                             {
-                                bytesRead = await this.WebSocketStream.ReadAsync(payloadLengthBuffer, totalBytesRead, payloadLengthBuffer.Length - totalBytesRead);
+                                bytesRead = await this.WebSocketStream.ReadAsync(payloadLengthBuffer, totalBytesRead, payloadLengthBuffer.Length - totalBytesRead).ConfigureAwait(false);
 
                                 if (bytesRead == 0)
                                 {
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.Devices.Client
                             {
                                 while (totalBytesRead < superExtendedPayloadLength)
                                 {
-                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, (int)(superExtendedPayloadLength - totalBytesRead));
+                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, (int)(superExtendedPayloadLength - totalBytesRead)).ConfigureAwait(false);
 
                                     if (bytesRead == 0)
                                     {
@@ -412,9 +412,9 @@ namespace Microsoft.Azure.Devices.Client
             try
             {
                 var webSocketHeader = PrepareWebSocketHeader(size, webSocketMessageType);
-                await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length);
+                await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length).ConfigureAwait(false);
                 MaskWebSocketData(buffer, offset, size);
-                await this.WebSocketStream.WriteAsync(buffer, offset, size);
+                await this.WebSocketStream.WriteAsync(buffer, offset, size).ConfigureAwait(false);
                 succeeded = true;
             }
             finally
@@ -436,7 +436,7 @@ namespace Microsoft.Azure.Devices.Client
                 {
                     var webSocketHeader = PrepareWebSocketHeader(0, WebSocketMessageType.Close);
 
-                    await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length);
+                    await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length).ConfigureAwait(false);
 
                     this.WebSocketStream?.Close();
 
@@ -827,7 +827,7 @@ namespace Microsoft.Azure.Devices.Client
                     this.TcpClient.Client.ReceiveTimeout = GetSocketTimeoutInMilliSeconds(timeoutHelper.RemainingTime());
                     this.bytesRead = 0;
 
-                    this.bytesRead = await this.Stream.ReadAsync(this.Buffer, this.TotalBytesRead, this.Buffer.Length - this.TotalBytesRead);
+                    this.bytesRead = await this.Stream.ReadAsync(this.Buffer, this.TotalBytesRead, this.Buffer.Length - this.TotalBytesRead).ConfigureAwait(false);
 
                     this.TotalBytesRead += this.bytesRead;
                     if (this.bytesRead == 0 || this.TryParseBuffer())

--- a/csharp/device/Microsoft.Azure.Devices.Client/IotHubConnection.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/IotHubConnection.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Client
             AmqpSession session;
             if (!this.FaultTolerantSession.TryGetOpenedObject(out session))
             {
-                session = await this.FaultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime());
+                session = await this.FaultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             var linkAddress = this.BuildLinkAddress(connectionString, path);
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Client
             link.AttachTo(session);
 
             var audience = this.BuildAudience(connectionString, path);
-            await this.OpenLinkAsync(link, connectionString, audience, timeoutHelper.RemainingTime());
+            await this.OpenLinkAsync(link, connectionString, audience, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             return link;
         }
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Client
             AmqpSession session;
             if (!this.FaultTolerantSession.TryGetOpenedObject(out session))
             {
-                session = await this.FaultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime());
+                session = await this.FaultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             var linkAddress = this.BuildLinkAddress(connectionString, path);
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices.Client
             link.AttachTo(session);
 
             var audience = this.BuildAudience(connectionString, path);
-            await this.OpenLinkAsync(link, connectionString, audience, timeoutHelper.RemainingTime());
+            await this.OpenLinkAsync(link, connectionString, audience, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             return link;
         }
@@ -161,13 +161,13 @@ namespace Microsoft.Azure.Devices.Client
             {
 #if !WINDOWS_UWP
                 case TransportType.Amqp_WebSocket_Only:
-                    transport = await this.CreateClientWebSocketTransportAsync(timeoutHelper.RemainingTime());
+                    transport = await this.CreateClientWebSocketTransportAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     break;
 #endif
                 case TransportType.Amqp_Tcp_Only:
                     TlsTransportSettings tlsTransportSettings = this.CreateTlsTransportSettings();
                     var amqpTransportInitiator = new AmqpTransportInitiator(amqpSettings, tlsTransportSettings);
-                    transport = await amqpTransportInitiator.ConnectTaskAsync(timeoutHelper.RemainingTime());
+                    transport = await amqpTransportInitiator.ConnectTaskAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     break;
                 default:
                     throw new InvalidOperationException("AmqpTransportSettings must specify WebSocketOnly or TcpOnly");
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.Client
             };
 
             var amqpConnection = new AmqpConnection(transport, amqpSettings, amqpConnectionSettings);
-            await amqpConnection.OpenAsync(timeoutHelper.RemainingTime());
+            await amqpConnection.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             var sessionSettings = new AmqpSessionSettings()
             {
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices.Client
             };
 
             var amqpSession = amqpConnection.CreateSession(sessionSettings);
-            await amqpSession.OpenAsync(timeoutHelper.RemainingTime());
+            await amqpSession.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // This adds itself to amqpConnection.Extensions
             var cbsLink = new AmqpCbsLink(amqpConnection);
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices.Client
 
             using (var cancellationTokenSource = new CancellationTokenSource(timeout))
             {
-                await websocket.ConnectAsync(websocketUri, cancellationTokenSource.Token);
+                await websocket.ConnectAsync(websocketUri, cancellationTokenSource.Token).ConfigureAwait(false);
             }
 
             return websocket;
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Devices.Client
             // Use Legacy WebSocket if it is running on Windows 7 or older. Windows 7/Windows 2008 R2 is version 6.1
             if (Environment.OSVersion.Version.Major < 6 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor <= 1))
             {
-                var websocket = await CreateLegacyClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime());
+                var websocket = await CreateLegacyClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 return new LegacyClientWebSocketTransport(
                     websocket,
                     this.AmqpTransportSettings.OperationTimeout,
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Devices.Client
             }
             else
             {
-                var websocket = await this.CreateClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime());
+                var websocket = await this.CreateClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 return new ClientWebSocketTransport(
                     websocket,
                     null,
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.Devices.Client
         static async Task<IotHubClientWebSocket> CreateLegacyClientWebSocketAsync(Uri webSocketUri,  TimeSpan timeout)
         {
             var websocket = new IotHubClientWebSocket(WebSocketConstants.SubProtocols.Amqpwsb10);
-            await websocket.ConnectAsync(webSocketUri.Host, webSocketUri.Port, WebSocketConstants.Scheme, timeout);
+            await websocket.ConnectAsync(webSocketUri.Host, webSocketUri.Port, WebSocketConstants.Scheme, timeout).ConfigureAwait(false);
             return websocket;
         }
 #endif

--- a/csharp/device/Microsoft.Azure.Devices.Client/IotHubDeviceMuxConnection.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/IotHubDeviceMuxConnection.cs
@@ -114,11 +114,11 @@ namespace Microsoft.Azure.Devices.Client
                     });
 
                     // Send Cbs token for new link first
-                    await iotHubLinkTokenRefresher.SendCbsTokenAsync(timeoutHelper.RemainingTime());
+                    await iotHubLinkTokenRefresher.SendCbsTokenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
                 // Open Amqp Link
-                await link.OpenAsync(timeoutHelper.RemainingTime());
+                await link.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             catch (Exception exception)
             {

--- a/csharp/device/Microsoft.Azure.Devices.Client/IotHubSingleTokenConnection.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/IotHubSingleTokenConnection.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Client
                 this.iotHubTokenRefresher.Cancel();
             }
 
-            AmqpSession amqpSession = await base.CreateSessionAsync(timeoutHelper.RemainingTime());
+            AmqpSession amqpSession = await base.CreateSessionAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
 #if !WINDOWS_UWP
             if (this.AmqpTransportSettings.ClientCertificate == null)
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Client
                    );
 
                 // Send Cbs token for new connection first
-                await this.iotHubTokenRefresher.SendCbsTokenAsync(timeoutHelper.RemainingTime());
+                await this.iotHubTokenRefresher.SendCbsTokenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 #if !WINDOWS_UWP
             }
 #endif
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Client
         {
             try
             {
-                await link.OpenAsync(timeout);
+                await link.OpenAsync(timeout).ConfigureAwait(false);
             }
             catch (Exception exception)
             {

--- a/csharp/device/Microsoft.Azure.Devices.Client/IotHubTokenRefresher.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/IotHubTokenRefresher.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Azure.Devices.Client
                 this.audience,
                 this.connectionString.AmqpEndpoint.AbsoluteUri,
                 AccessRightsStringArray,
-                timeout);
+                timeout).ConfigureAwait(false);
             this.SendCbsTokenLoopAsync(expiresAtUtc, timeout).Fork();
         }
 
         async Task SendCbsTokenLoopAsync(DateTime expiryTimeUtc, TimeSpan timeout)
         {
-            bool continueSendingTokens = await WaitUntilNextTokenSendTime(expiryTimeUtc);
+            bool continueSendingTokens = await WaitUntilNextTokenSendTime(expiryTimeUtc).ConfigureAwait(false);
 
             if (!continueSendingTokens)
             {
@@ -82,9 +82,9 @@ namespace Microsoft.Azure.Devices.Client
                                  this.audience,
                                  this.connectionString.AmqpEndpoint.AbsoluteUri,
                                  AccessRightsStringArray,
-                                 timeout);
+                                 timeout).ConfigureAwait(false);
 
-                            continueSendingTokens = await WaitUntilNextTokenSendTime(expiresAtUtc);
+                            continueSendingTokens = await WaitUntilNextTokenSendTime(expiresAtUtc).ConfigureAwait(false);
                             if (!continueSendingTokens)
                             {
                                 break;
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Devices.Client
                                 throw;
                             }
 
-                            await Task.Delay(RefreshTokenRetryInterval);
+                            await Task.Delay(RefreshTokenRetryInterval).ConfigureAwait(false);
                         }
                     }
                     else
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.Client
                 return false;
             }
 
-            await Task.Delay(waitTime);
+            await Task.Delay(waitTime).ConfigureAwait(false);
             return true;
         }
 

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/AmqpTransportHandler.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             {
                 await Task.WhenAll(
                     this.faultTolerantEventSendingLink.OpenAsync(this.openTimeout),
-                    this.faultTolerantDeviceBoundReceivingLink.OpenAsync(this.openTimeout));
+                    this.faultTolerantDeviceBoundReceivingLink.OpenAsync(this.openTimeout)).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             Outcome outcome;
             using (AmqpMessage amqpMessage = message.ToAmqpMessage())
             {
-                outcome = await this.SendAmqpMessageAsync(amqpMessage);
+                outcome = await this.SendAmqpMessageAsync(amqpMessage).ConfigureAwait(false);
             }
 
             if (outcome.DescriptorCode != Accepted.Code)
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             using (AmqpMessage amqpMessage = AmqpMessage.Create(messageList))
             {
                 amqpMessage.MessageFormat = AmqpConstants.AmqpBatchedMessageFormat;
-                outcome = await this.SendAmqpMessageAsync(amqpMessage);
+                outcome = await this.SendAmqpMessageAsync(amqpMessage).ConfigureAwait(false);
             }
 
             if (outcome.DescriptorCode != Accepted.Code)
@@ -191,8 +191,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
             AmqpMessage amqpMessage;
             try
             {
-                ReceivingAmqpLink deviceBoundReceivingLink = await this.GetDeviceBoundReceivingLinkAsync();
-                amqpMessage = await deviceBoundReceivingLink.ReceiveMessageAsync(timeout);
+                ReceivingAmqpLink deviceBoundReceivingLink = await this.GetDeviceBoundReceivingLinkAsync().ConfigureAwait(false);
+                amqpMessage = await deviceBoundReceivingLink.ReceiveMessageAsync(timeout).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -240,8 +240,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
             Outcome outcome;
             try
             {
-                SendingAmqpLink eventSendingLink = await this.GetEventSendingLinkAsync();
-                outcome = await eventSendingLink.SendMessageAsync(amqpMessage, IotHubConnection.GetNextDeliveryTag(ref this.eventsDeliveryTag), AmqpConstants.NullBinary, this.operationTimeout);
+                SendingAmqpLink eventSendingLink = await this.GetEventSendingLinkAsync().ConfigureAwait(false);
+                outcome = await eventSendingLink.SendMessageAsync(amqpMessage, IotHubConnection.GetNextDeliveryTag(ref this.eventsDeliveryTag), AmqpConstants.NullBinary, this.operationTimeout).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -263,8 +263,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
             Outcome disposeOutcome;
             try
             {
-                ReceivingAmqpLink deviceBoundReceivingLink = await this.GetDeviceBoundReceivingLinkAsync();
-                disposeOutcome = await deviceBoundReceivingLink.DisposeMessageAsync(deliveryTag, outcome, batchable: true, timeout: this.operationTimeout);
+                ReceivingAmqpLink deviceBoundReceivingLink = await this.GetDeviceBoundReceivingLinkAsync().ConfigureAwait(false);
+                disposeOutcome = await deviceBoundReceivingLink.DisposeMessageAsync(deliveryTag, outcome, batchable: true, timeout: this.operationTimeout).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             SendingAmqpLink eventSendingLink;
             if (!this.faultTolerantEventSendingLink.TryGetOpenedObject(out eventSendingLink))
             {
-                eventSendingLink = await this.faultTolerantEventSendingLink.GetOrCreateAsync(this.openTimeout);
+                eventSendingLink = await this.faultTolerantEventSendingLink.GetOrCreateAsync(this.openTimeout).ConfigureAwait(false);
             }
             return eventSendingLink;
         }
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             string path = string.Format(CultureInfo.InvariantCulture, CommonConstants.DeviceEventPathTemplate, System.Net.WebUtility.UrlEncode(this.deviceId));
 
-            return await this.IotHubConnection.CreateSendingLinkAsync(path, this.iotHubConnectionString, timeout);
+            return await this.IotHubConnection.CreateSendingLinkAsync(path, this.iotHubConnectionString, timeout).ConfigureAwait(false);
         }
 
         async Task<ReceivingAmqpLink> GetDeviceBoundReceivingLinkAsync()
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             ReceivingAmqpLink deviceBoundReceivingLink;
             if (!this.faultTolerantDeviceBoundReceivingLink.TryGetOpenedObject(out deviceBoundReceivingLink))
             {
-                deviceBoundReceivingLink = await this.faultTolerantDeviceBoundReceivingLink.GetOrCreateAsync(this.openTimeout);
+                deviceBoundReceivingLink = await this.faultTolerantDeviceBoundReceivingLink.GetOrCreateAsync(this.openTimeout).ConfigureAwait(false);
             }
 
             return deviceBoundReceivingLink;
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             string path = string.Format(CultureInfo.InvariantCulture, CommonConstants.DeviceBoundPathTemplate, System.Net.WebUtility.UrlEncode(this.deviceId));
 
-            return await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, timeout, this.prefetchCount);
+            return await this.IotHubConnection.CreateReceivingLinkAsync(path, this.iotHubConnectionString, timeout, this.prefetchCount).ConfigureAwait(false);
         }
     }
 }

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/ErrorDelegatingHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/ErrorDelegatingHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     this.InnerHandler = this.handlerFactory();
                     try
                     {
-                        await this.ExecuteWithErrorHandlingAsync(() => base.OpenAsync(explicitOpen), false);
+                        await this.ExecuteWithErrorHandlingAsync(() => base.OpenAsync(explicitOpen), false).ConfigureAwait(false);
                         openPromise.TrySetResult(0);
                     }
                     catch (Exception ex) when (this.IsTranportTransient(ex))
@@ -82,12 +82,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 }
                 else
                 {
-                    await currentOpenPromise.Task;
+                    await currentOpenPromise.Task.ConfigureAwait(false);
                 }
             }
             else
             {
-                await openPromise.Task;
+                await openPromise.Task.ConfigureAwait(false);
             }
         }
 
@@ -128,14 +128,14 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         async Task<T> ExecuteWithErrorHandlingAsync<T>(Func<Task<T>> asyncOperation)
         {
-            await this.EnsureOpenAsync();
+            await this.EnsureOpenAsync().ConfigureAwait(false);
 
             TaskCompletionSource<int> completedPromise = this.openCompletion;
 
             IDelegatingHandler handler = this.InnerHandler;
             try
             {
-                return await asyncOperation();
+                return await asyncOperation().ConfigureAwait(false);
             }
             catch (Exception ex) when (!ex.IsFatal())
             {
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             if (ensureOpen)
             {
-                await this.EnsureOpenAsync();
+                await this.EnsureOpenAsync().ConfigureAwait(false);
             }
 
             TaskCompletionSource<int> completedPromise = this.openCompletion;
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
             try
             {
-                await asyncOperation();
+                await asyncOperation().ConfigureAwait(false);
             }
             catch (Exception ex) when (!ex.IsFatal())
             {
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             {
                 if (handler != null)
                 {
-                    await handler.CloseAsync();
+                    await handler.CloseAsync().ConfigureAwait(false);
                 }
             }
             catch (Exception ex) when (!ex.IsFatal())

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/GateKeeperDelegatingHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/GateKeeperDelegatingHandler.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <returns>The receive message or null if there was no message until the specified time has elapsed</returns>
         public override async Task<Message> ReceiveAsync()
         {
-            await this.EnsureOpenedAsync(false);
-            return await base.ReceiveAsync();
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            return await base.ReceiveAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -53,8 +53,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         public override async Task<Message> ReceiveAsync(TimeSpan timeout)
         {
             TimeoutHelper.ThrowIfNegativeArgument(timeout);
-            await this.EnsureOpenedAsync(false);
-            return await base.ReceiveAsync(timeout);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            return await base.ReceiveAsync(timeout).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -63,8 +63,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <returns>The lock identifier for the previously received message</returns>
         public override async Task CompleteAsync(string lockToken)
         {
-            await this.EnsureOpenedAsync(false);
-            await base.CompleteAsync(lockToken);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await base.CompleteAsync(lockToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -73,8 +73,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <returns>The previously received message</returns>
         public override async Task AbandonAsync(string lockToken)
         {
-            await this.EnsureOpenedAsync(false);
-            await base.AbandonAsync(lockToken);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await base.AbandonAsync(lockToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <returns>The previously received message</returns>
         public override async Task RejectAsync(string lockToken)
         {
-            await this.EnsureOpenedAsync(false);
-            await base.RejectAsync(lockToken);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await base.RejectAsync(lockToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -93,8 +93,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <returns>The message containing the event</returns>
         public override async Task SendEventAsync(Message message)
         {
-            await this.EnsureOpenedAsync(false);
-            await base.SendEventAsync(message);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await base.SendEventAsync(message).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -103,8 +103,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <returns>The task containing the event</returns>
         public override async Task SendEventAsync(IEnumerable<Message> messages)
         {
-            await this.EnsureOpenedAsync(false);
-            await base.SendEventAsync(messages);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await base.SendEventAsync(messages).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             if (!this.TryCloseGate())
             {
-                await base.CloseAsync();
+                await base.CloseAsync().ConfigureAwait(false);
             }
         }
 

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/HttpTransportHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/HttpTransportHandler.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             fileUploadRequest,
             ExceptionHandlingHelper.GetDefaultErrorMapping(),
             null,
-            CancellationToken.None);
+            CancellationToken.None).ConfigureAwait(false);
 
             string putString = String.Format("https://{0}/{1}/{2}{3}",
                 fileUploadResponse.HostName,
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 // 2. Use SAS URI to send data to Azure Storage Blob (PUT)
                 CloudBlockBlob blob = new CloudBlockBlob(new Uri(putString));
                 var uploadTask = blob.UploadFromStreamAsync(source);
-                await uploadTask;
+                await uploadTask.ConfigureAwait(false);
 
                 notification.CorrelationId = fileUploadResponse.CorrelationId;
                 notification.IsSuccess = uploadTask.IsCompleted;
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     notification,
                     ExceptionHandlingHelper.GetDefaultErrorMapping(),
                     null,
-                    CancellationToken.None);
+                    CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     notification,
                     ExceptionHandlingHelper.GetDefaultErrorMapping(),
                     null,
-                    CancellationToken.None);
+                    CancellationToken.None).ConfigureAwait(false);
 
                 throw ex;
             }
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 ExceptionHandlingHelper.GetDefaultErrorMapping(),
                 customHeaders,
                 true,
-                CancellationToken.None);
+                CancellationToken.None).ConfigureAwait(false);
 
             if (responseMessage.StatusCode == HttpStatusCode.NoContent)
             {
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             IEnumerable<string> sequenceNumber;
             responseMessage.Headers.TryGetValues(CustomHeaderConstants.SequenceNumber, out sequenceNumber);
 
-            var byteContent = await responseMessage.Content.ReadAsByteArrayAsync();
+            var byteContent = await responseMessage.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
             var message = byteContent != null ? new Message(byteContent) : new Message();
 

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/ConcurrentObjectPool.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/ConcurrentObjectPool.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         {
             try
             {
-                await this.disposeCallback(obj);
+                await this.disposeCallback(obj).ConfigureAwait(false);
             }
             catch (Exception ex) when (!ex.IsFatal())
             {

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/OrderedTwoPhaseWorkQueue.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/OrderedTwoPhaseWorkQueue.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
         protected override async Task DoWorkAsync(IChannelHandlerContext context, TWork work)
         {
-            await base.DoWorkAsync(context, work);
+            await base.DoWorkAsync(context, work).ConfigureAwait(false);
             this.incompleteQueue.Enqueue(new IncompleteWorkItem(this.getWorkId(work), work));
         }
 

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/SimpleWorkQueue.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/SimpleWorkQueue.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 while (queue.Count > 0 && this.State != States.Aborted)
                 {
                     TWork workItem = queue.Dequeue();
-                    await this.DoWorkAsync(context, workItem);
+                    await this.DoWorkAsync(context, workItem).ConfigureAwait(false);
                 }
 
                 switch (this.State)

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/Util.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/Util.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
                 int length = (int)streamLength;
                 IByteBuffer buffer = context.Channel.Allocator.Buffer(length, length);
-                await buffer.WriteBytesAsync(payloadStream, length);
+                await buffer.WriteBytesAsync(payloadStream, length).ConfigureAwait(false);
                 Contract.Assert(buffer.ReadableBytes == length);
 
                 packet.Payload = buffer;
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         {
             try
             {
-                await context.WriteAndFlushAsync(message);
+                await context.WriteAndFlushAsync(message).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/RetryDelegatingHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/RetryDelegatingHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             try
             {
                 var sendState = new SendMessageState();
-                await this.retryPolicy.ExecuteAsync(() => this.SendMessageWithRetryAsync(sendState, message, () => base.SendEventAsync(message)));
+                await this.retryPolicy.ExecuteAsync(() => this.SendMessageWithRetryAsync(sendState, message, () => base.SendEventAsync(message))).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             {
                 var sendState = new SendMessageState();
                 IEnumerable<Message> messageList = messages as IList<Message> ?? messages.ToList();
-                await this.retryPolicy.ExecuteAsync(() => this.SendMessageWithRetryAsync(sendState, messageList, () => base.SendEventAsync(messageList)));
+                await this.retryPolicy.ExecuteAsync(() => this.SendMessageWithRetryAsync(sendState, messageList, () => base.SendEventAsync(messageList))).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             try
             {
-                return await this.retryPolicy.ExecuteAsync(() => base.ReceiveAsync());
+                return await this.retryPolicy.ExecuteAsync(() => base.ReceiveAsync()).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             try
             {
-                return await this.retryPolicy.ExecuteAsync(() => base.ReceiveAsync(timeout));
+                return await this.retryPolicy.ExecuteAsync(() => base.ReceiveAsync(timeout)).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             try
             {
-                await this.retryPolicy.ExecuteAsync(() => base.CompleteAsync(lockToken));
+                await this.retryPolicy.ExecuteAsync(() => base.CompleteAsync(lockToken)).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             try
             {
-                await this.retryPolicy.ExecuteAsync(() => base.AbandonAsync(lockToken));
+                await this.retryPolicy.ExecuteAsync(() => base.AbandonAsync(lockToken)).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             try
             {
-                await this.retryPolicy.ExecuteAsync(() => base.RejectAsync(lockToken));
+                await this.retryPolicy.ExecuteAsync(() => base.RejectAsync(lockToken)).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         {
             try
             {
-                await this.retryPolicy.ExecuteAsync(() => base.OpenAsync(explicitOpen));
+                await this.retryPolicy.ExecuteAsync(() => base.OpenAsync(explicitOpen)).ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {
@@ -171,13 +171,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     message.TryResetBody(messageStreamPosition);
                 }
 
-                await TryExecuteActionAsync(sendState, action);
+                await TryExecuteActionAsync(sendState, action).ConfigureAwait(false);
                 return;
             }
 
             EnsureStreamsAreInOriginalState(sendState, messages);
 
-            await TryExecuteActionAsync(sendState, action);
+            await TryExecuteActionAsync(sendState, action).ConfigureAwait(false);
         }
 
         async Task SendMessageWithRetryAsync(SendMessageState sendState, Message message, Func<Task> action)
@@ -187,13 +187,13 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 sendState.InitialStreamPosition = message.BodyStream.CanSeek ? message.BodyStream.Position : UndeterminedPosition;
                 message.TryResetBody(sendState.InitialStreamPosition);
 
-                await TryExecuteActionAsync(sendState, action);
+                await TryExecuteActionAsync(sendState, action).ConfigureAwait(false);
                 return;
             }
 
             EnsureStreamIsInOriginalState(sendState, message);
 
-            await TryExecuteActionAsync(sendState, action);
+            await TryExecuteActionAsync(sendState, action).ConfigureAwait(false);
         }
 
         static void EnsureStreamsAreInOriginalState(SendMessageState sendState, IEnumerable<Message> messages)
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             sendState.Iteration++;
             try
             {
-                await action();
+                await action().ConfigureAwait(false);
             }
             catch (IotHubClientTransientException ex)
             {

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/RoutingDelegatingHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/RoutingDelegatingHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
 
         public override async Task OpenAsync(bool explicitOpen)
         {
-            await this.TryOpenPrioritizedTransportsAsync(explicitOpen);
+            await this.TryOpenPrioritizedTransportsAsync(explicitOpen).ConfigureAwait(false);
         }
 
         async Task TryOpenPrioritizedTransportsAsync(bool explicitOpen)
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     this.InnerHandler = this.transportHandlerFactory(this.iotHubConnectionString, transportSetting);
 
                     // Try to open a connection with this transport
-                    await base.OpenAsync(explicitOpen);
+                    await base.OpenAsync(explicitOpen).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     {
                         if (this.InnerHandler != null)
                         {
-                            await this.CloseAsync();
+                            await this.CloseAsync().ConfigureAwait(false);
                         }
                     }
                     catch (Exception ex) when (!ex.IsFatal())

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/TransportHandlerBase.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/TransportHandlerBase.cs
@@ -78,8 +78,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
         public async Task<Message> ReceiveAsync(TimeSpan timeout)
         {
             TimeoutHelper.ThrowIfNegativeArgument(timeout);
-            await this.EnsureOpenedAsync(false);
-            return await this.OnReceiveAsync(timeout);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            return await this.OnReceiveAsync(timeout).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -93,8 +93,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("lockToken");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnCompleteAsync(lockToken);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnCompleteAsync(lockToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("message");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnCompleteAsync(message);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnCompleteAsync(message).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -123,8 +123,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("lockToken");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnAbandonAsync(lockToken);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnAbandonAsync(lockToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -138,8 +138,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("message");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnAbandonAsync(message);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnAbandonAsync(message).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -153,8 +153,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("lockToken");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnRejectAsync(lockToken);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnRejectAsync(lockToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -168,8 +168,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("message");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnRejectAsync(message);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnRejectAsync(message).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -183,8 +183,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("message");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnSendEventAsync(message);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnSendEventAsync(message).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -198,8 +198,8 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 throw Fx.Exception.ArgumentNull("messages");
             }
 
-            await this.EnsureOpenedAsync(false);
-            await this.OnSendEventAsync(messages);
+            await this.EnsureOpenedAsync(false).ConfigureAwait(false);
+            await this.OnSendEventAsync(messages).ConfigureAwait(false);
         }
 
         protected Task EnsureOpenedAsync(bool explicitOpen)

--- a/csharp/service/Microsoft.Azure.Devices/AmqpClientHelper.cs
+++ b/csharp/service/Microsoft.Azure.Devices/AmqpClientHelper.cs
@@ -67,8 +67,8 @@ namespace Microsoft.Azure.Devices
             Outcome disposeOutcome;
             try
             {
-                ReceivingAmqpLink deviceBoundReceivingLink = await faultTolerantReceivingLink.GetReceivingLinkAsync();
-                disposeOutcome = await deviceBoundReceivingLink.DisposeMessageAsync(deliveryTag, outcome, batchable, IotHubConnection.DefaultOperationTimeout);
+                ReceivingAmqpLink deviceBoundReceivingLink = await faultTolerantReceivingLink.GetReceivingLinkAsync().ConfigureAwait(false);
+                disposeOutcome = await deviceBoundReceivingLink.DisposeMessageAsync(deliveryTag, outcome, batchable, IotHubConnection.DefaultOperationTimeout).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Devices
         {
             using (var reader = new StreamReader(amqpMessage.BodyStream, Encoding.UTF8))
             {
-                string jsonString = await reader.ReadToEndAsync();
+                string jsonString = await reader.ReadToEndAsync().ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(jsonString);
             }
         }

--- a/csharp/service/Microsoft.Azure.Devices/AmqpFeedbackReceiver.cs
+++ b/csharp/service/Microsoft.Azure.Devices/AmqpFeedbackReceiver.cs
@@ -71,15 +71,15 @@ namespace Microsoft.Azure.Devices
         {
             try
             {
-                ReceivingAmqpLink receivingLink = await this.faultTolerantReceivingLink.GetReceivingLinkAsync();
-                AmqpMessage amqpMessage = await receivingLink.ReceiveMessageAsync(timeout);
+                ReceivingAmqpLink receivingLink = await this.faultTolerantReceivingLink.GetReceivingLinkAsync().ConfigureAwait(false);
+                AmqpMessage amqpMessage = await receivingLink.ReceiveMessageAsync(timeout).ConfigureAwait(false);
 
                 if (amqpMessage != null)
                 {
                     using (amqpMessage)
                     {
                         AmqpClientHelper.ValidateContentType(amqpMessage, CommonConstants.BatchedFeedbackContentType);
-                        var records = await AmqpClientHelper.GetObjectFromAmqpMessageAsync<IEnumerable<FeedbackRecord>>(amqpMessage);
+                        var records = await AmqpClientHelper.GetObjectFromAmqpMessageAsync<IEnumerable<FeedbackRecord>>(amqpMessage).ConfigureAwait(false);
 
                         return new FeedbackBatch
                         {

--- a/csharp/service/Microsoft.Azure.Devices/AmqpFileNotificationReceiver.cs
+++ b/csharp/service/Microsoft.Azure.Devices/AmqpFileNotificationReceiver.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Azure.Devices
         {
             try
             {
-                ReceivingAmqpLink receivingLink = await this.faultTolerantReceivingLink.GetReceivingLinkAsync();
-                AmqpMessage amqpMessage = await receivingLink.ReceiveMessageAsync(timeout);
+                ReceivingAmqpLink receivingLink = await this.faultTolerantReceivingLink.GetReceivingLinkAsync().ConfigureAwait(false);
+                AmqpMessage amqpMessage = await receivingLink.ReceiveMessageAsync(timeout).ConfigureAwait(false);
 
                 if (amqpMessage != null)
                 {
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Devices
                     {
                         AmqpClientHelper.ValidateContentType(amqpMessage, CommonConstants.FileNotificationContentType);
 
-                        var fileNotification = await AmqpClientHelper.GetObjectFromAmqpMessageAsync<FileNotification>(amqpMessage);
+                        var fileNotification = await AmqpClientHelper.GetObjectFromAmqpMessageAsync<FileNotification>(amqpMessage).ConfigureAwait(false);
                         fileNotification.LockToken = new Guid(amqpMessage.DeliveryTag.Array).ToString();
 
                         return fileNotification;

--- a/csharp/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
+++ b/csharp/service/Microsoft.Azure.Devices/AmqpServiceClient.cs
@@ -94,14 +94,14 @@ namespace Microsoft.Azure.Devices
 
         public override async Task OpenAsync()
         {
-            await this.GetSendingLinkAsync();
-            await this.feedbackReceiver.OpenAsync();
+            await this.GetSendingLinkAsync().ConfigureAwait(false);
+            await this.feedbackReceiver.OpenAsync().ConfigureAwait(false);
         }
 
         public async override Task CloseAsync()
         {
-            await this.feedbackReceiver.CloseAsync();
-            await this.iotHubConnection.CloseAsync();
+            await this.feedbackReceiver.CloseAsync().ConfigureAwait(false);
+            await this.iotHubConnection.CloseAsync().ConfigureAwait(false);
         }
 
         public async override Task SendAsync(string deviceId, Message message)
@@ -122,8 +122,8 @@ namespace Microsoft.Azure.Devices
                 amqpMessage.Properties.To = "/devices/" + WebUtility.UrlEncode(deviceId) + "/messages/deviceBound";
                 try
                 {
-                    SendingAmqpLink sendingLink = await this.GetSendingLinkAsync();
-                    outcome = await sendingLink.SendMessageAsync(amqpMessage, IotHubConnection.GetNextDeliveryTag(ref this.sendingDeliveryTag), AmqpConstants.NullBinary, this.OperationTimeout);
+                    SendingAmqpLink sendingLink = await this.GetSendingLinkAsync().ConfigureAwait(false);
+                    outcome = await sendingLink.SendMessageAsync(amqpMessage, IotHubConnection.GetNextDeliveryTag(ref this.sendingDeliveryTag), AmqpConstants.NullBinary, this.OperationTimeout).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices
             SendingAmqpLink sendingLink;
             if (!this.faultTolerantSendingLink.TryGetOpenedObject(out sendingLink))
             {
-                sendingLink = await this.faultTolerantSendingLink.GetOrCreateAsync(this.OpenTimeout);
+                sendingLink = await this.faultTolerantSendingLink.GetOrCreateAsync(this.OpenTimeout).ConfigureAwait(false);
             }
 
             return sendingLink;

--- a/csharp/service/Microsoft.Azure.Devices/Common/Amqp/ClientWebSocketTransport.cs
+++ b/csharp/service/Microsoft.Azure.Devices/Common/Amqp/ClientWebSocketTransport.cs
@@ -81,14 +81,14 @@ namespace Microsoft.Azure.Devices
                 if (args.Buffer != null)
                 {
                     var arraySegment = new ArraySegment<byte>(args.Buffer, args.Offset, args.Count);
-                    await this.webSocket.SendAsync(arraySegment, WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token);
+                    await this.webSocket.SendAsync(arraySegment, WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token).ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (ByteBuffer byteBuffer in args.ByteBufferList)
                     {
                         await this.webSocket.SendAsync(new ArraySegment<byte>(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length),
-                            WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token);
+                            WebSocketMessageType.Binary, true, this.writeCancellationTokenSource.Token).ConfigureAwait(false);
                     }
                 }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices
             try
             {
                 WebSocketReceiveResult receiveResult = await this.webSocket.ReceiveAsync(
-                    new ArraySegment<byte>(args.Buffer, args.Offset, args.Count), CancellationToken.None);
+                    new ArraySegment<byte>(args.Buffer, args.Offset, args.Count), CancellationToken.None).ConfigureAwait(false);
 
                 succeeded = true;
                 return receiveResult.Count;
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.Devices
 
                 using (var cancellationTokenSource = new CancellationTokenSource(timeout))
                 {
-                    await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token);
+                    await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
                 }
             }
             catch (Exception e)

--- a/csharp/service/Microsoft.Azure.Devices/Common/Amqp/LegacyClientWebSocketTransport.cs
+++ b/csharp/service/Microsoft.Azure.Devices/Common/Amqp/LegacyClientWebSocketTransport.cs
@@ -85,13 +85,13 @@ namespace Microsoft.Azure.Devices
             {
                 if (args.Buffer != null)
                 {
-                    await this.webSocket.SendAsync(args.Buffer, args.Offset, args.Count, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout);
+                    await this.webSocket.SendAsync(args.Buffer, args.Offset, args.Count, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout).ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (ByteBuffer byteBuffer in args.ByteBufferList)
                     {
-                        await this.webSocket.SendAsync(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout);
+                        await this.webSocket.SendAsync(byteBuffer.Buffer, byteBuffer.Offset, byteBuffer.Length, IotHubClientWebSocket.WebSocketMessageType.Binary, this.operationTimeout).ConfigureAwait(false);
                     }
                 }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices
             bool succeeded = false;
             try
             {
-                int numBytes = await this.webSocket.ReceiveAsync(this.asyncReadBuffer, this.asyncReadBufferOffset, this.asyncReadBufferSize, this.operationTimeout);
+                int numBytes = await this.webSocket.ReceiveAsync(this.asyncReadBuffer, this.asyncReadBufferOffset, this.asyncReadBufferSize, this.operationTimeout).ConfigureAwait(false);
 
                 succeeded = true;
                 return numBytes;
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices
         {
             try
             {
-               await this.webSocket.CloseAsync();
+               await this.webSocket.CloseAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/csharp/service/Microsoft.Azure.Devices/Common/Extensions/AmqpExtensions.cs
+++ b/csharp/service/Microsoft.Azure.Devices/Common/Extensions/AmqpExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Common.Extensions
             ReceivingAmqpLink receivingLink;
             if (!faultTolerantReceivingLink.TryGetOpenedObject(out receivingLink))
             {
-                receivingLink = await faultTolerantReceivingLink.GetOrCreateAsync(IotHubConnection.DefaultOpenTimeout);
+                receivingLink = await faultTolerantReceivingLink.GetOrCreateAsync(IotHubConnection.DefaultOpenTimeout).ConfigureAwait(false);
             }
 
             return receivingLink;

--- a/csharp/service/Microsoft.Azure.Devices/Common/SingletonDictionary.cs
+++ b/csharp/service/Microsoft.Azure.Devices/Common/SingletonDictionary.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Common
                 TaskCompletionSource<TValue> tcs;
                 if (this.dictionary.TryGetValue(key, out tcs))
                 {
-                    return await tcs.Task;
+                    return await tcs.Task.ConfigureAwait(false);
                 }
 
                 tcs = new TaskCompletionSource<TValue>();
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Common
         {
             try
             {
-                TValue value = await OnCreateAsync(key, timeout);
+                TValue value = await OnCreateAsync(key, timeout).ConfigureAwait(false);
                 tcs.SetResult(value);
 
                 if (this.disposed)

--- a/csharp/service/Microsoft.Azure.Devices/Common/TaskHelpers.cs
+++ b/csharp/service/Microsoft.Azure.Devices/Common/TaskHelpers.cs
@@ -364,16 +364,16 @@ namespace Microsoft.Azure.Devices.Common
 
             if (task.IsCompleted || (timeout == Timeout.InfiniteTimeSpan && token == CancellationToken.None))
             {
-                await task;
+                await task.ConfigureAwait(false);
                 return;
             }
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
-                if (task == await Task.WhenAny(task, CreateDelayTask(timeout, cts.Token)))
+                if (task == await Task.WhenAny(task, CreateDelayTask(timeout, cts.Token)).ConfigureAwait(false))
                 {
                     cts.Cancel();
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
             }
         }
@@ -400,16 +400,16 @@ namespace Microsoft.Azure.Devices.Common
 
             if (task.IsCompleted || (timeout == Timeout.InfiniteTimeSpan && token == CancellationToken.None))
             {
-                await task;
+                await task.ConfigureAwait(false);
                 return;
             }
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
-                if (task == await Task.WhenAny(task, CreateDelayTask(timeout, cts.Token)))
+                if (task == await Task.WhenAny(task, CreateDelayTask(timeout, cts.Token)).ConfigureAwait(false))
                 {
                     cts.Cancel();
-                    await task;
+                    await task.ConfigureAwait(false);
                     return;
                 }
             }
@@ -439,15 +439,15 @@ namespace Microsoft.Azure.Devices.Common
 
             if (task.IsCompleted || (timeout == Timeout.InfiniteTimeSpan && token == CancellationToken.None))
             {
-                return await task;
+                return await task.ConfigureAwait(false);
             }
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
-                if (task == await Task.WhenAny(task, CreateDelayTask(timeout, cts.Token)))
+                if (task == await Task.WhenAny(task, CreateDelayTask(timeout, cts.Token)).ConfigureAwait(false))
                 {
                     cts.Cancel();
-                    return await task;
+                    return await task.ConfigureAwait(false);
                 }
             }
 
@@ -458,7 +458,7 @@ namespace Microsoft.Azure.Devices.Common
         {
             try
             {
-                await Task.Delay(timeout, token);
+                await Task.Delay(timeout, token).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {

--- a/csharp/service/Microsoft.Azure.Devices/ExceptionHandlingHelper.cs
+++ b/csharp/service/Microsoft.Azure.Devices/ExceptionHandlingHelper.cs
@@ -17,16 +17,16 @@ namespace Microsoft.Azure.Devices
         {
             var mappings = new Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>();
 
-            mappings.Add(HttpStatusCode.NoContent, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.NotFound, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.Conflict, async (response) => new DeviceAlreadyExistsException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.BadRequest, async (response) => new ArgumentException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.Unauthorized, async (response) => new UnauthorizedException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.Forbidden, async (response) => new QuotaExceededException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.PreconditionFailed, async (response) => new DeviceMessageLockLostException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.RequestEntityTooLarge, async (response) => new MessageTooLargeException(await GetExceptionMessageAsync(response))); ;
-            mappings.Add(HttpStatusCode.InternalServerError, async (response) => new ServerErrorException(await GetExceptionMessageAsync(response)));
-            mappings.Add(HttpStatusCode.ServiceUnavailable, async (response) => new ServerBusyException(await GetExceptionMessageAsync(response)));
+            mappings.Add(HttpStatusCode.NoContent, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.NotFound, async (response) => new DeviceNotFoundException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.Conflict, async (response) => new DeviceAlreadyExistsException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.BadRequest, async (response) => new ArgumentException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.Unauthorized, async (response) => new UnauthorizedException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.Forbidden, async (response) => new QuotaExceededException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.PreconditionFailed, async (response) => new DeviceMessageLockLostException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.RequestEntityTooLarge, async (response) => new MessageTooLargeException(await GetExceptionMessageAsync(response).ConfigureAwait(false))); ;
+            mappings.Add(HttpStatusCode.InternalServerError, async (response) => new ServerErrorException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
+            mappings.Add(HttpStatusCode.ServiceUnavailable, async (response) => new ServerBusyException(await GetExceptionMessageAsync(response).ConfigureAwait(false)));
 
             return mappings;
         }

--- a/csharp/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/csharp/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -157,10 +157,10 @@ namespace Microsoft.Azure.Devices
 
             var errorMappingOverrides = new Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>()
             {
-                { HttpStatusCode.PreconditionFailed, async (responseMessage) => new PreconditionFailedException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage)) },
+                { HttpStatusCode.PreconditionFailed, async (responseMessage) => new PreconditionFailedException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false)) },
                 { HttpStatusCode.NotFound, async responseMessage =>
                                            {
-                                               string responseContent = await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage);
+                                               string responseContent = await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false);
                                                return (Exception) new DeviceNotFoundException(responseContent, (Exception) null);
                                            }
                 }
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.Devices
             this.EnsureInstanceNotClosed();
             var errorMappingOverrides = new Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>()
             {
-                { HttpStatusCode.NotFound, async responseMessage => new DeviceNotFoundException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage)) }
+                { HttpStatusCode.NotFound, async responseMessage => new DeviceNotFoundException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false)) }
             };
 
             return this.httpClientHelper.GetAsync<Device>(GetRequestUri(deviceId), errorMappingOverrides, null, false, cancellationToken);
@@ -402,8 +402,8 @@ namespace Microsoft.Azure.Devices
 
             var errorMappingOverrides = new Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>
             {
-                { HttpStatusCode.RequestEntityTooLarge, async responseMessage => new TooManyDevicesException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage)) },
-                { HttpStatusCode.BadRequest, async responseMessage => new ArgumentException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage)) }
+                { HttpStatusCode.RequestEntityTooLarge, async responseMessage => new TooManyDevicesException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false)) },
+                { HttpStatusCode.BadRequest, async responseMessage => new ArgumentException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false)) }
             };
 
             return this.httpClientHelper.PostAsync<IEnumerable<ExportImportDevice>, T>(GetBulkRequestUri(version), devices, errorMappingOverrides, null, cancellationToken);
@@ -626,11 +626,11 @@ namespace Microsoft.Azure.Devices
             {
                 { HttpStatusCode.NotFound, async responseMessage =>
                                            {
-                                               string responseContent = await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage);
+                                               string responseContent = await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false);
                                                return new DeviceNotFoundException(responseContent, (Exception) null);
                                            }
                 },
-                { HttpStatusCode.PreconditionFailed, async responseMessage => new PreconditionFailedException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage)) }
+                { HttpStatusCode.PreconditionFailed, async responseMessage => new PreconditionFailedException(await ExceptionHandlingHelper.GetExceptionMessageAsync(responseMessage).ConfigureAwait(false)) }
             };
             
             return this.httpClientHelper.DeleteAsync(GetRequestUri(deviceId), eTagHolder, errorMappingOverrides, null, cancellationToken);

--- a/csharp/service/Microsoft.Azure.Devices/IotHubClientWebSocket.cs
+++ b/csharp/service/Microsoft.Azure.Devices/IotHubClientWebSocket.cs
@@ -156,13 +156,13 @@ namespace Microsoft.Azure.Devices
             {
                 // Connect without proxy
                 this.TcpClient = new TcpClient();
-                await this.TcpClient.ConnectAsync(host, port);
+                await this.TcpClient.ConnectAsync(host, port).ConfigureAwait(false);
 
                 if (string.Equals(WebSocketConstants.Scheme, scheme, StringComparison.OrdinalIgnoreCase))
                 {
                     // In the real world, web-socket will happen over HTTPS
                     var sslStream = new SslStream(this.TcpClient.GetStream(), false, IotHubConnection.OnRemoteCertificateValidation);
-                    await sslStream.AuthenticateAsClientAsync(host);
+                    await sslStream.AuthenticateAsClientAsync(host).ConfigureAwait(false);
                     this.WebSocketStream = sslStream;
                 }
                 else
@@ -176,14 +176,14 @@ namespace Microsoft.Azure.Devices
                 this.TcpClient.Client.SendTimeout = GetSocketTimeoutInMilliSeconds(timeout);
 
                 // Send WebSocket Upgrade request
-                await this.WebSocketStream.WriteAsync(upgradeRequestBytes, 0, upgradeRequestBytes.Length);
+                await this.WebSocketStream.WriteAsync(upgradeRequestBytes, 0, upgradeRequestBytes.Length).ConfigureAwait(false);
 
                 // receive WebSocket Upgrade response
                 var responseBuffer = new byte[8 * 1024];
 
                 var upgradeResponse = new HttpResponse(this.TcpClient, this.WebSocketStream, responseBuffer);
 
-                await upgradeResponse.ReadAsync(timeout);
+                await upgradeResponse.ReadAsync(timeout).ConfigureAwait(false);
 
                 if (upgradeResponse.StatusCode != HttpStatusCode.SwitchingProtocols)
                 {
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices
                     totalBytesRead = 0;
                     do
                     {
-                        bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead);
+                        bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead).ConfigureAwait(false);
                         if (bytesRead == 0)
                         {
                             throw new IOException(FramingPrematureEOF, new InvalidDataException("IotHubClientWebSocket was expecting more bytes"));
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices
                         // Encountered a close frame or error in parsing frame from server. Close connection
                         var closeHeader = PrepareWebSocketHeader(0, WebSocketMessageType.Close);
 
-                        await this.WebSocketStream.WriteAsync(closeHeader, 0, closeHeader.Length);
+                        await this.WebSocketStream.WriteAsync(closeHeader, 0, closeHeader.Length).ConfigureAwait(false);
 
                         this.State = WebSocketState.Closed;
                         this.WebSocketStream?.Close();
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices
                         var tempBuffer = new byte[payloadLength];
                         while (totalBytesRead < payloadLength)
                         {
-                            bytesRead = await this.WebSocketStream.ReadAsync(tempBuffer, totalBytesRead, payloadLength - totalBytesRead);
+                            bytesRead = await this.WebSocketStream.ReadAsync(tempBuffer, totalBytesRead, payloadLength - totalBytesRead).ConfigureAwait(false);
                             if (bytesRead == 0)
                             {
                                 throw new IOException(FramingPrematureEOF, new InvalidDataException("IotHubClientWebSocket was expecting more bytes"));
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.Devices
                 {
                     while (totalBytesRead < payloadLength)
                     {
-                        bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, payloadLength - totalBytesRead);
+                        bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, payloadLength - totalBytesRead).ConfigureAwait(false);
 
                         if (bytesRead == 0)
                         {
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Devices
                             // read payload length (< 64K)
                             do
                             {
-                                bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead);
+                                bytesRead = await this.WebSocketStream.ReadAsync(header, totalBytesRead, header.Length - totalBytesRead).ConfigureAwait(false);
 
                                 if (bytesRead == 0)
                                 {
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices
                             {
                                 while (totalBytesRead < extendedPayloadLength)
                                 {
-                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, extendedPayloadLength - totalBytesRead);
+                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, extendedPayloadLength - totalBytesRead).ConfigureAwait(false);
 
                                     if (bytesRead == 0)
                                     {
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Devices
                             var payloadLengthBuffer = new byte[8];
                             do
                             {
-                                bytesRead = await this.WebSocketStream.ReadAsync(payloadLengthBuffer, totalBytesRead, payloadLengthBuffer.Length - totalBytesRead);
+                                bytesRead = await this.WebSocketStream.ReadAsync(payloadLengthBuffer, totalBytesRead, payloadLengthBuffer.Length - totalBytesRead).ConfigureAwait(false);
 
                                 if (bytesRead == 0)
                                 {
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.Devices
                             {
                                 while (totalBytesRead < superExtendedPayloadLength)
                                 {
-                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, (int)(superExtendedPayloadLength - totalBytesRead));
+                                    bytesRead = await this.WebSocketStream.ReadAsync(buffer, offset + totalBytesRead, (int)(superExtendedPayloadLength - totalBytesRead)).ConfigureAwait(false);
 
                                     if (bytesRead == 0)
                                     {
@@ -412,9 +412,9 @@ namespace Microsoft.Azure.Devices
             try
             {
                 var webSocketHeader = PrepareWebSocketHeader(size, webSocketMessageType);
-                await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length);
+                await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length).ConfigureAwait(false);
                 MaskWebSocketData(buffer, offset, size);
-                await this.WebSocketStream.WriteAsync(buffer, offset, size);
+                await this.WebSocketStream.WriteAsync(buffer, offset, size).ConfigureAwait(false);
                 succeeded = true;
             }
             finally
@@ -436,7 +436,7 @@ namespace Microsoft.Azure.Devices
                 {
                     var webSocketHeader = PrepareWebSocketHeader(0, WebSocketMessageType.Close);
 
-                    await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length);
+                    await this.WebSocketStream.WriteAsync(webSocketHeader, 0, webSocketHeader.Length).ConfigureAwait(false);
 
                     this.WebSocketStream?.Close();
 
@@ -827,7 +827,7 @@ namespace Microsoft.Azure.Devices
                     this.TcpClient.Client.ReceiveTimeout = GetSocketTimeoutInMilliSeconds(timeoutHelper.RemainingTime());
                     this.bytesRead = 0;
 
-                    this.bytesRead = await this.Stream.ReadAsync(this.Buffer, this.TotalBytesRead, this.Buffer.Length - this.TotalBytesRead);
+                    this.bytesRead = await this.Stream.ReadAsync(this.Buffer, this.TotalBytesRead, this.Buffer.Length - this.TotalBytesRead).ConfigureAwait(false);
 
                     this.TotalBytesRead += this.bytesRead;
                     if (this.bytesRead == 0 || this.TryParseBuffer())

--- a/csharp/service/Microsoft.Azure.Devices/IotHubConnection.cs
+++ b/csharp/service/Microsoft.Azure.Devices/IotHubConnection.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices
             AmqpSession session;
             if (!this.faultTolerantSession.TryGetOpenedObject(out session))
             {
-                session = await this.faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime());
+                session = await this.faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             var linkAddress = this.connectionString.BuildLinkAddress(path);
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices
             var link = new SendingAmqpLink(linkSettings);
             link.AttachTo(session);
 
-            await OpenLinkAsync(link, timeoutHelper.RemainingTime());
+            await OpenLinkAsync(link, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             return link;
         }
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices
             AmqpSession session;
             if (!this.faultTolerantSession.TryGetOpenedObject(out session))
             {
-                session = await this.faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime());
+                session = await this.faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             var linkAddress = this.connectionString.BuildLinkAddress(path);
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Devices
             var link = new ReceivingAmqpLink(linkSettings);
             link.AttachTo(session);
 
-            await OpenLinkAsync(link, timeoutHelper.RemainingTime());
+            await OpenLinkAsync(link, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             return link;
         }
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices
             AmqpSession session;
             if (!this.faultTolerantSession.TryGetOpenedObject(out session))
             {
-                session = await this.faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime());
+                session = await this.faultTolerantSession.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             var linkAddress = this.connectionString.BuildLinkAddress(path);
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Devices
 
             var link = new RequestResponseAmqpLink(session, linkSettings);
 
-            await OpenLinkAsync(link, timeoutHelper.RemainingTime());
+            await OpenLinkAsync(link, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             return link;
         }
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Devices
             if (this.useWebSocketOnly)
             {
                 // Try only Amqp transport over WebSocket
-                transport = await this.CreateClientWebSocketTransport(timeoutHelper.RemainingTime());
+                transport = await this.CreateClientWebSocketTransport(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             else
             {             
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Devices
                 var amqpTransportInitiator = new AmqpTransportInitiator(amqpSettings, tlsTransportSettings);
                 try
                 {
-                    transport = await amqpTransportInitiator.ConnectTaskAsync(timeoutHelper.RemainingTime());
+                    transport = await amqpTransportInitiator.ConnectTaskAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Devices
                     // Amqp transport over TCP failed. Retry Amqp transport over WebSocket
                     if (timeoutHelper.RemainingTime() != TimeSpan.Zero)
                     {
-                        transport = await this.CreateClientWebSocketTransport(timeoutHelper.RemainingTime());
+                        transport = await this.CreateClientWebSocketTransport(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     }
                     else
                     {
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Devices
             };
 
             var amqpConnection = new AmqpConnection(transport, amqpSettings, amqpConnectionSettings);
-            await amqpConnection.OpenAsync(timeoutHelper.RemainingTime());
+            await amqpConnection.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             var sessionSettings = new AmqpSessionSettings()
             {
@@ -246,11 +246,11 @@ namespace Microsoft.Azure.Devices
             };
 
             var amqpSession = amqpConnection.CreateSession(sessionSettings);
-            await amqpSession.OpenAsync(timeoutHelper.RemainingTime());
+            await amqpSession.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // This adds itself to amqpConnection.Extensions
             var cbsLink = new AmqpCbsLink(amqpConnection);
-            await this.SendCbsTokenAsync(cbsLink, timeoutHelper.RemainingTime());
+            await this.SendCbsTokenAsync(cbsLink, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             return amqpSession;
         }
 
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Devices
 
             using (var cancellationTokenSource = new CancellationTokenSource(timeout))
             {
-                await websocket.ConnectAsync(websocketUri, cancellationTokenSource.Token);
+                await websocket.ConnectAsync(websocketUri, cancellationTokenSource.Token).ConfigureAwait(false);
             }
 
             return websocket;
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Devices
         static async Task<IotHubClientWebSocket> CreateLegacyClientWebSocketAsync(Uri webSocketUri, TimeSpan timeout)
         {
             var websocket = new IotHubClientWebSocket(WebSocketConstants.SubProtocols.Amqpwsb10);
-            await websocket.ConnectAsync(webSocketUri.Host, webSocketUri.Port, WebSocketConstants.Scheme, timeout);
+            await websocket.ConnectAsync(webSocketUri.Host, webSocketUri.Port, WebSocketConstants.Scheme, timeout).ConfigureAwait(false);
             return websocket;
         }
 #endif
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.Devices
             // Use Legacy WebSocket if it is running on Windows 7 or older. Windows 7/Windows 2008 R2 is version 6.1
             if (Environment.OSVersion.Version.Major < 6 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor <= 1))
             {
-                var websocket = await CreateLegacyClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime());
+                var websocket = await CreateLegacyClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 return new LegacyClientWebSocketTransport(
                     websocket,
                     DefaultOperationTimeout,
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.Devices
             }
             else
             {
-                var websocket = await CreateClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime());
+                var websocket = await CreateClientWebSocketAsync(websocketUri, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 return new ClientWebSocketTransport(
                     websocket,
                     null,
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Devices
             var timeoutHelper = new TimeoutHelper(timeout);
             try
             {
-                await link.OpenAsync(timeoutHelper.RemainingTime());
+                await link.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -392,7 +392,7 @@ namespace Microsoft.Azure.Devices
                 audience,
                 resource,
                 AccessRightsHelper.AccessRightsToStringArray(this.accessRights),
-                timeout);
+                timeout).ConfigureAwait(false);
             this.ScheduleTokenRefresh(expiresAtUtc);
         }
 
@@ -406,7 +406,7 @@ namespace Microsoft.Azure.Devices
                 {
                     try
                     {
-                        await this.SendCbsTokenAsync(cbsLink, DefaultOperationTimeout);
+                        await this.SendCbsTokenAsync(cbsLink, DefaultOperationTimeout).ConfigureAwait(false);
                     }
                     catch (Exception exception)
                     {


### PR DESCRIPTION
Hi,
I wrote a broad but trivial patch to avoid potential dead lock due to lack of `CongifureAwait(false)` in awaiting.

### Motivation

As Stphen Toub said [in pfx team blog post](https://blogs.msdn.microsoft.com/pfxteam/2012/04/13/should-i-expose-synchronous-wrappers-for-asynchronous-methods/) and some articles (for example, [this thread in Stackoverflow](http://stackoverflow.com/questions/28410046/revisiting-task-configureawaitcontinueoncapturedcontext-false) ), libraries should always call `ConfigureAwait(false)` before awaiting except there are special reason(s).
```c#
// Not recommended in library -- implicitly captured SynchronizationContext may cause dead lock.
await someThing.DoAsync(...);
// Recommended -- this is done on ThreadPool, libraries should always do as it.
await someThing.DoAsync(...).ConfigureAwait(false);
```

Indeed, IoT SDK's code does not have any `ConfigureAwait(false)`, so my collegue faced dead lock in ASP.NET program when he tried to call `RegsitryManager` APIs.

### Solution

Just put `ConfigureAwait(false)` immediately before awaiting. This patch simply put it for all occurances of `await` except unit test code.

### Note

* I didn't look inside of dependent libraries including AMQP and/or MQTT.
* I didn't put `ConfigureAwait(false)` to the unit test code. It should be free for unit test framework to use their own `SynchronizationContext` to do anything for asynchronous test execution.
