### PR TITLE
Added Typescript typings for common and common/transport NodeJS modules

### DIFF
--- a/node/common/core/common.d.ts
+++ b/node/common/core/common.d.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { anHourFromNow, encodeUriComponentStrict } from './lib/authorization';
+export import ConnectionString = require('./lib/connection_string');
+export import endpoint = require('./lib/endpoint');
+export import errors = require('./lib/errors');
+export import results = require('./lib/results');
+export import Message = require('./lib/message');
+export import SharedAccessSignature = require('./lib/shared_access_signature');
+
+// Typescript only, used by other modules in azure-iot-sdk
+interface X509 {
+    // https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
+    cert: string | string[] | Buffer | Buffer[];
+    key: string | Buffer;
+    passphrase?: string;    
+}

--- a/node/common/core/lib/authorization.d.ts
+++ b/node/common/core/lib/authorization.d.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export function anHourFromNow(): number;
+export function encodeUriComponentStrict(str: string): string;
+export function stringToSign(resourceUri: string, expiry: string): string;
+export function hmacHash(password: string, stringToSign: string): string;

--- a/node/common/core/lib/connection_string.d.ts
+++ b/node/common/core/lib/connection_string.d.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// While it doesn't have any parameters that WILL be there,
+// there are some that are expected to be there beacuse of the Azure connection string format
+declare interface ConnectionString {
+    HostName?: string;
+    DeviceId?: string;
+    SharedAccessKey?: string;
+    GatewayHostName?: string;
+}
+
+declare namespace ConnectionString {
+    export function parse(source: string, requiredFields?: string[]): ConnectionString;
+}
+
+export = ConnectionString;

--- a/node/common/core/lib/dictionary.d.ts
+++ b/node/common/core/lib/dictionary.d.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+declare function createDictionary(source: string, seperator: string): createDictionary.Dictionary<string>;
+
+declare namespace createDictionary {
+    interface Dictionary<T> {
+        [key: string]: T;
+    }
+}
+
+export = createDictionary;

--- a/node/common/core/lib/endpoint.d.ts
+++ b/node/common/core/lib/endpoint.d.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export function devicePath(id: string): string;
+export function eventPath(id: string): string;
+export function messagePath(id: string): string;
+export function feedbackPath(id: string, lockToken: string): string;
+export function versionQueryString(): string;

--- a/node/common/core/lib/errors.d.ts
+++ b/node/common/core/lib/errors.d.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export declare class ArgumentError extends Error {
+    constructor(message: string);
+}
+
+export declare class DeviceMaximumQueueDepthExceededError extends Error {
+    constructor(message: string);
+}
+
+export declare class DeviceNotFoundError extends Error {
+    constructor(message: string);
+}
+
+export declare class FormatError extends Error {
+    constructor(message: string);
+}
+
+export declare class UnauthorizedError extends Error {
+    constructor(message: string);
+}
+
+export declare class NotImplementedError extends Error {
+    constructor(message: string);
+}
+
+export declare class NotConnectedError extends Error {
+    constructor(message: string);
+}
+
+export declare class IotHubQuotaExceededError extends Error {
+    constructor(message: string);
+}
+
+export declare class MessageTooLargeError extends Error {
+    constructor(message: string);
+}
+
+export declare class InternalServerError extends Error {
+    constructor(message: string);
+}
+
+export declare class ServiceUnavailableError extends Error {
+    constructor(message: string);
+}
+
+export declare class IotHubNotFoundError extends Error {
+    constructor(message: string);
+}
+
+export declare class JobNotFoundError extends Error {
+    constructor(message: string);
+}
+
+export declare class TooManyDevicesError extends Error {
+    constructor(message: string);
+}
+
+export declare class ThrottlingError extends Error {
+    constructor(message: string);
+}
+
+export declare class DeviceAlreadyExistsError extends Error {
+    constructor(message: string);
+}
+
+export declare class InvalidEtagError extends Error {
+    constructor(message: string);
+}

--- a/node/common/core/lib/message.d.ts
+++ b/node/common/core/lib/message.d.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import Properties = require('./properties');
+
+declare class Message {
+    properties: Properties;
+    messageId: string;
+    to: string;
+    expiryTimeUtc: Date;
+    lockToken: string;
+    correlationId: string;
+    userId: string;
+
+    constructor(data: Message.BufferConvertable);
+
+    getData(): Message.BufferConvertable;
+    getBytes(): Buffer;
+}
+
+declare namespace Message {
+    type BufferConvertable = Buffer | String | any[] | ArrayBuffer;
+}
+
+export = Message;

--- a/node/common/core/lib/properties.d.ts
+++ b/node/common/core/lib/properties.d.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+declare class Properties {
+    add(itemKey: string, itemValue: string): boolean;
+    getItem(index: number): Properties.PropertyPair;
+    count(): number;
+}
+
+declare namespace Properties {
+    interface KeyValuePair<K, V> {
+        key: K;
+        value: V;
+    }
+    type PropertyPair = KeyValuePair<string, string>
+}
+
+export = Properties;

--- a/node/common/core/lib/results.d.ts
+++ b/node/common/core/lib/results.d.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// TODO: Check where result.js is used and specify the objects more
+
+// Typescript only interface
+export interface Result {
+    tranportObj?: any;
+}
+
+export declare class MessageEnqueued implements Result {
+    constructor(tranportObj?: any);
+}
+
+export declare class MessageCompleted implements Result {
+    constructor(tranportObj?: any);
+}
+
+export declare class MessageRejected implements Result {
+    constructor(tranportObj?: any);
+}
+
+export declare class MessageAbandoned implements Result {
+    constructor(tranportObj?: any);
+}
+
+export declare class Connected implements Result {
+    constructor(tranportObj?: any);
+}
+
+export declare class Disconnected implements Result {
+    constructor(tranportObj: any, reason: string);
+}
+export declare class TransportConfigured implements Result {
+    constructor(tranportObj?: any);
+}
+
+export declare class SharedAccessSignatureUpdated implements Result {
+    constructor(tranportObj?: any);
+}

--- a/node/common/core/lib/shared_access_signature.d.ts
+++ b/node/common/core/lib/shared_access_signature.d.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+declare class SharedAccessSignature {
+    sr: string;
+    sig: string;
+    skn: string;
+    se: string;
+
+    toString(): string;
+
+    static create(resourceUri: string, keyName: string, key: string, expiry: string): SharedAccessSignature;
+    static parse(source: string, requiredFields?: string[]): SharedAccessSignature;
+}
+
+export = SharedAccessSignature;

--- a/node/common/core/package.json
+++ b/node/common/core/package.json
@@ -1,10 +1,11 @@
 {
   "name": "azure-iot-common",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Common components shared by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "main": "common.js",
+  "typings": "commond.d.ts",
   "dependencies": {
     "crypto": "^0.0.3"
   },
@@ -12,10 +13,12 @@
     "chai": "^3.5.0",
     "istanbul": "^0.4.4",
     "jshint": "^2.9.2",
-    "mocha": "^3.0.1"
+    "mocha": "^3.0.1",
+    "tslint": "^3.14.0",
+    "typescript": "^1.8.10"
   },
   "scripts": {
-    "lint": "jshint --show-non-errors .",
+    "lint": "jshint --show-non-errors . && tslint -c ../../tslint.json \"{lib,.}/*.ts\"",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",
     "unittest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test.js",

--- a/node/common/core/typings.json
+++ b/node/common/core/typings.json
@@ -1,0 +1,8 @@
+{
+  "name": "azure-iot-common",
+  "main": "commond.t.s",
+  "dependencies": {},
+  "globalDependencies": {
+    "node": "registry:dt/node#6.0.0+20160807145350"
+  }
+}

--- a/node/common/transport/amqp/index.d.ts
+++ b/node/common/transport/amqp/index.d.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export import Amqp = require('./lib/amqp');
+export import AmqpMessage = require('./lib/amqp_message');
+export import AmqpReceiver = require('./lib/amqp_receiver');
+export import translateError = require('./lib/amqp_common_errors');

--- a/node/common/transport/amqp/lib/amqp.d.ts
+++ b/node/common/transport/amqp/lib/amqp.d.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Policy } from 'amqp10';
+
+import { Message } from 'azure-iot-common';
+import { results } from 'azure-iot-common';
+
+import AmqpReceiver = require('./amqp_receiver');
+
+declare class Amqp {
+    constructor(autoSettleMessage: boolean, sdkVersionString: string);
+
+    connect(uri: string, sslOptions: Policy.Options.SSLOptions, done?: (err: Error, result?: results.Connected) => void): void;
+    setDisconnectHandler(disconnectCallback: (msg: string) => void): void;
+    disconnect(done?: (err: Error) => void): void;
+    send(message: Message, endpoint: string, to: string, done?: (err: Error, result?: results.MessageEnqueued) => void): void;
+    getReceiver(endpoint: string, done: (err: Error, receiver?: AmqpReceiver) => void): void;
+}
+
+export = Amqp;

--- a/node/common/transport/amqp/lib/amqp_common_errors.d.ts
+++ b/node/common/transport/amqp/lib/amqp_common_errors.d.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Errors as AmqpErrors } from 'amqp10';
+
+declare function translateError(message: string, amqpError: AmqpErrors.BaseError): Error;
+
+export = translateError;

--- a/node/common/transport/amqp/lib/amqp_message.d.ts
+++ b/node/common/transport/amqp/lib/amqp_message.d.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Message } from 'azure-iot-common';
+
+declare interface AmqpMessage {
+    properties: AmqpMessage.Properties;
+    body?: Buffer;
+}
+
+declare namespace AmqpMessage {
+    export function fromMessage(message: Message): AmqpMessage;
+
+    interface Dictionary<T> {
+        [key: string]: T;
+    }
+
+    interface Properties {
+        to?: string;
+        absoluteExpiryTime?: Date;
+        messageId?: string;
+        applicationProperties: Dictionary<string>;
+    }
+}
+
+export = AmqpMessage;

--- a/node/common/transport/amqp/lib/amqp_receiver.d.ts
+++ b/node/common/transport/amqp/lib/amqp_receiver.d.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventEmitter } from 'events';
+import { ReceiverLink as Amqp10ReceiverLink } from 'amqp10';
+import { results } from 'azure-iot-common';
+
+import AmqpMessage = require('./amqp_message');
+
+declare class AmqpReceiver extends EventEmitter {
+    constructor(amqpReceiver: Amqp10ReceiverLink);
+
+    complete(message: AmqpMessage, done?: (err: Error, result?: results.MessageCompleted) => void): void;
+    abandon(message: AmqpMessage, done?: (err: Error, result?: results.MessageAbandoned) => void): void;
+    reject(message: AmqpMessage, done?: (err: Error, result?: results.MessageRejected) => void): void;
+}
+
+export = AmqpReceiver;

--- a/node/common/transport/amqp/package.json
+++ b/node/common/transport/amqp/package.json
@@ -1,23 +1,27 @@
 {
   "name": "azure-iot-amqp-base",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "AMQP operations used by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",
+  "main": "main.js",
+  "typings": "index.d.ts",
   "dependencies": {
     "amqp10": "^3.2.1",
     "amqp10-transport-ws": "^0.0.4",
-    "azure-iot-common": "1.0.11",
+    "azure-iot-common": "1.0.12",
     "debug": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "istanbul": "^0.4.4",
     "jshint": "^2.9.2",
-    "mocha": "^3.0.1"
+    "mocha": "^3.0.1",
+    "tslint": "^3.14.0",
+    "typescript": "^1.8.10"
   },
   "scripts": {
-    "lint": "jshint --show-non-errors .",
+    "lint": "jshint --show-non-errors . && tslint -c ../../../tslint.json \"{lib,.}/*.ts\"",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",
     "unittest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test.js",

--- a/node/common/transport/amqp/typings.json
+++ b/node/common/transport/amqp/typings.json
@@ -1,0 +1,11 @@
+{
+  "name": "azure-iot-amqp-base",
+  "main": "index.d.ts",
+  "dependencies": {
+    "amqp10": "registry:npm/amqp10#3.1.4+20160601175358"
+  },
+  "globalDependencies": {
+    "es2015-promise": "registry:env/es2015-promise#1.0.0+20160526151700",
+    "node": "registry:dt/node#6.0.0+20160807145350"
+  }
+}

--- a/node/common/transport/http/index.d.ts
+++ b/node/common/transport/http/index.d.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export import Http = require('./lib/http');

--- a/node/common/transport/http/lib/http.d.ts
+++ b/node/common/transport/http/lib/http.d.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ServerResponse, ClientRequest, IncomingMessage } from 'http';
+import { Message, X509 } from 'azure-iot-common';
+
+declare class Http {
+    // x509Options might be casted to done function in case it's optional and then done parameter should be null
+    buildRequest(
+        method: Http.Method,
+        path: string,
+        httpHeaders: Http.Dictionary<Http.HeaderLike>,
+        host: string,
+        x509Options: X509 | Http.DoneCallback,
+        done?: Http.DoneCallback): ClientRequest;
+
+    toMessage(response: IncomingMessage, body: Message.BufferConvertable): Message;
+    parseErrorBody(body: string): { code: string, message: string };
+}
+
+declare namespace Http {
+    interface Dictionary<T> {
+        [key: string]: T;
+    }
+
+    // https://nodejs.org/api/http.html#http_message_headers
+    type HeaderLike = string | string[] | number;
+    type Method = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE";
+
+    type DoneCallback = (err: Error, body?: string, response?: ServerResponse) => void;
+}
+
+export = Http;

--- a/node/common/transport/http/lib/http.js
+++ b/node/common/transport/http/lib/http.js
@@ -81,11 +81,11 @@ Http.prototype.buildRequest = function (method, path, httpHeaders, host, x509Opt
 };
 
 /**
- * @method              module:azure-iot-http-base.Http.toMessage
- * @description         Transforms the body of an HTTP response into a {@link module:azure-iot-common.Message} that can be treated by the client.
+ * @method                              module:azure-iot-http-base.Http.toMessage
+ * @description                         Transforms the body of an HTTP response into a {@link module:azure-iot-common.Message} that can be treated by the client.
  *
- * @param {Object}      response          The HTTP verb to use (GET, POST, PUT, DELETE...).
- * @param {Object}      body            The section of the URI that should be appended after the hostname.
+ * @param {module:http.IncomingMessage} response        A response as returned from the node.js http module
+ * @param {Object}                      body            The section of the URI that should be appended after the hostname.
  *
  * @returns {module:azure-iot-common.Message} A Message object.
  */

--- a/node/common/transport/http/package.json
+++ b/node/common/transport/http/package.json
@@ -4,18 +4,22 @@
   "description": "HTTP operations used by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",
+  "main": "index.js",
+  "typings": "index.d.ts",
   "dependencies": {
-    "azure-iot-common": "1.0.11",
+    "azure-iot-common": "1.0.12",
     "debug": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "istanbul": "^0.4.4",
     "jshint": "^2.9.2",
-    "mocha": "^3.0.1"
+    "mocha": "^3.0.1",
+    "tslint": "^3.14.0",
+    "typescript": "^1.8.10"
   },
   "scripts": {
-    "lint": "jshint --show-non-errors .",
+    "lint": "jshint --show-non-errors . && tslint -c ../../../tslint.json \"{lib,.}/*.ts\"",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",
     "unittest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test.js",

--- a/node/common/transport/http/typings.json
+++ b/node/common/transport/http/typings.json
@@ -1,0 +1,8 @@
+{
+  "name": "azure-iot-http-base",
+  "main": "index.d.ts",
+  "dependencies": {},
+  "globalDependencies": {
+    "node": "registry:dt/node#6.0.0+20160807145350"
+  }
+}

--- a/node/common/transport/mqtt/index.d.ts
+++ b/node/common/transport/mqtt/index.d.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export import Mqtt = require('./lib/mqtt');
+export import MqttReceiver = require('./lib/mqtt_receiver');

--- a/node/common/transport/mqtt/lib/mqtt.d.ts
+++ b/node/common/transport/mqtt/lib/mqtt.d.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Packet } from 'mqtt';
+import { X509, results } from 'azure-iot-common';
+import MqttReceiver = require('./mqtt_receiver');
+
+declare class Mqtt {
+    // There is currently no way for the parameter to be a whole TypeScript namespace
+    constructor(mqttprovider: any);
+    connect(config: Mqtt.ConnectOptions, done: (err: Error, ack?: Packet) => void): void;
+    disconnect(done: () => void): void;
+    publish(message: { data: { toString(): string }}, done: (err: Error, result?: results.MessageEnqueued) => void): void;
+    getReceiver(done: (err: Error, receiver: MqttReceiver) => void): void;
+}
+
+declare namespace Mqtt {
+    interface ConnectOptions {
+        host: string;
+        deviceId: string;
+        sharedAccessSignature?: string;
+        x509?: X509;
+    }
+}
+
+export = Mqtt;

--- a/node/common/transport/mqtt/lib/mqtt_receiver.d.ts
+++ b/node/common/transport/mqtt/lib/mqtt_receiver.d.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventEmitter } from 'events';
+import { Client as MqttClient } from 'mqtt';
+
+declare class MqttReceiver extends EventEmitter {
+    // Want to have the same variables as the source
+    // tslint:disable-next-line:variable-name
+    constructor(mqttClient: MqttClient, topic_subscribe: string);
+}
+
+export = MqttReceiver;

--- a/node/common/transport/mqtt/package.json
+++ b/node/common/transport/mqtt/package.json
@@ -1,11 +1,13 @@
 {
   "name": "azure-iot-mqtt-base",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "MQTT operations used by Azure IoT device and service SDKs",
   "author": "Microsoft Corporation",
   "license": "MIT",
+  "main": "index.js",
+  "typings": "index.d.ts",
   "dependencies": {
-    "azure-iot-common": "1.0.11",
+    "azure-iot-common": "1.0.12",
     "debug": "^2.2.0",
     "mqtt": "^1.5.0"
   },
@@ -14,10 +16,12 @@
     "istanbul": "^0.4.4",
     "jshint": "^2.9.2",
     "mocha": "^3.0.1",
-    "sinon": "^1.17.5"
+    "sinon": "^1.17.5",
+    "tslint": "^3.14.0",
+    "typescript": "^1.8.10"
   },
   "scripts": {
-    "lint": "jshint --show-non-errors .",
+    "lint": "jshint --show-non-errors . && tslint -c ../../../tslint.json \"{lib,.}/*.ts\"",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",
     "unittest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test.js",

--- a/node/common/transport/mqtt/typings.json
+++ b/node/common/transport/mqtt/typings.json
@@ -1,0 +1,9 @@
+{
+  "name": "azure-iot-mqtt-base",
+  "main": "index.d.ts",
+  "dependencies": {},
+  "globalDependencies": {
+    "mqtt": "registry:dt/mqtt#0.0.0+20160317120654",
+    "node": "registry:dt/node#6.0.0+20160807145350"
+  }
+}

--- a/node/tslint.json
+++ b/node/tslint.json
@@ -1,0 +1,65 @@
+{
+    "rules": {
+        "member-ordering": [
+            true,
+            { "order": "instance-sandwich" }
+        ],
+        "no-var-requires": true,
+        "typedef": [
+            true,
+            "call-signature",
+            "parameter",
+            "property-declaration",
+            "member-variable-declaration"
+        ],
+        "typedef-whitespace": [
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            },
+            {
+                "call-signature": "onespace",
+                "index-signature": "onespace",
+                "parameter": "onespace",
+                "property-declaration": "onespace",
+                "variable-declaration": "onespace"
+            }
+        ],
+        "label-undefined": true,
+        "no-construct": true,
+        "no-duplicate-key": true,
+        "no-duplicate-variable": true,
+        "no-empty": true,
+        "no-invalid-this": true,
+        "no-null-keyword": true,
+        "no-string-literal": true,
+        "no-switch-case-fall-through": true,
+        "no-unreachable": true,
+        "no-unsafe-finally": true,
+        "no-unused-expression": true,
+        "no-unused-variable": true,
+        "no-use-before-declare": true,
+        "no-var-keyword": true,
+        "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
+        "use-isnan": true,
+        "eofline": true,
+        "indent": [true, "spaces"],
+        "no-trailing-whitespace": true,
+        "arrow-parens": true,
+        "class-name": true,
+        "comment-format": [true, "check-space"],
+        "interface-name": [true, "never-prefix"],
+        "jsdoc-format": true,
+        "new-parens": true,
+        "one-line": [true, "check-catch", "check-finally", "check-else", "check-open-brace"],
+        "one-variable-per-declaration": [true, "ignore-for-loop"],
+        "quotemark": [true, "single"],
+        "semicolon": [true, "always"],
+        "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
+        "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-module", "check-seperator", "check-type"]
+    }
+}


### PR DESCRIPTION
Seperating work and code reviews into more managable, working chunks, typings for device/service modules will be coming later.
There are no tests for the typings (at least yet). Probably a discussion is in order to decide on a best way of testing those.

Issue about typings: #181 