### PR TITLE
Empty CorrelationId

### DIFF
--- a/c/iothub_service_client/inc/iothub_messaging_ll.h
+++ b/c/iothub_service_client/inc/iothub_messaging_ll.h
@@ -49,7 +49,7 @@ typedef struct IOTHUB_SERVICE_FEEDBACK_RECORD_TAG
 {
     char* description;
     const char* deviceId;
-    const char* correlationId;
+    const char* originalMessageId;
     const char* generationId;
     const char* enqueuedTimeUtc;
     IOTHUB_FEEDBACK_STATUS_CODE statusCode;

--- a/c/iothub_service_client/src/iothub_messaging_ll.c
+++ b/c/iothub_service_client/src/iothub_messaging_ll.c
@@ -67,6 +67,7 @@ static const char* FEEDBACK_RECORD_KEY_DEVICE_ID = "deviceId";
 static const char* FEEDBACK_RECORD_KEY_DEVICE_GENERATION_ID = "deviceGenerationId";
 static const char* FEEDBACK_RECORD_KEY_DESCRIPTION = "description";
 static const char* FEEDBACK_RECORD_KEY_ENQUED_TIME_UTC = "enqueuedTimeUtc";
+static const char* FEEDBACK_RECORD_KEY_ORIGINAL_MESSAGE_ID = "originalMessageId";
 
 static char* createSasToken(IOTHUB_MESSAGING_HANDLE messagingHandle)
 {
@@ -443,7 +444,7 @@ static AMQP_VALUE IoTHubMessaging_LL_FeedbackMessageReceived(const void* context
                                 feedbackRecord->generationId = (char*)json_object_get_string(feedback_object, FEEDBACK_RECORD_KEY_DEVICE_GENERATION_ID);
                                 feedbackRecord->description = (char*)json_object_get_string(feedback_object, FEEDBACK_RECORD_KEY_DESCRIPTION);
                                 feedbackRecord->enqueuedTimeUtc = (char*)json_object_get_string(feedback_object, FEEDBACK_RECORD_KEY_ENQUED_TIME_UTC);
-                                feedbackRecord->correlationId = "";
+                                feedbackRecord->originalMessageId = (char*)json_object_get_string(feedback_object, FEEDBACK_RECORD_KEY_ORIGINAL_MESSAGE_ID);
 
                                 if (feedbackRecord->description == NULL)
                                 {

--- a/java/service/iothub-service-sdk/src/main/java/com/microsoft/azure/iot/service/sdk/FeedbackBatchMessage.java
+++ b/java/service/iothub-service-sdk/src/main/java/com/microsoft/azure/iot/service/sdk/FeedbackBatchMessage.java
@@ -54,7 +54,10 @@ public class FeedbackBatchMessage
                         FeedbackRecord feedbackRecord = new FeedbackRecord();
 
                         feedbackRecord.setEnqueuedTimeUtc(Instant.parse(Tools.getValueFromJsonObject(jsonObject, "enqueuedTimeUtc")));
-                        feedbackRecord.setCorrelationId("");
+                        
+                        String originalMessageId = Tools.getValueFromJsonObject(jsonObject, "originalMessageId");
+                        feedbackRecord.setOriginalMessageId(originalMessageId);
+                        
                         String description = Tools.getValueFromJsonObject(jsonObject, "description");
                         feedbackRecord.setDescription(description);
                         if (description.toLowerCase().equals("success"))

--- a/java/service/iothub-service-sdk/src/main/java/com/microsoft/azure/iot/service/sdk/FeedbackRecord.java
+++ b/java/service/iothub-service-sdk/src/main/java/com/microsoft/azure/iot/service/sdk/FeedbackRecord.java
@@ -25,16 +25,16 @@ public class FeedbackRecord
         this.enqueuedTimeUtc = enqueuedTimeUtc;
     }
 
-    private String correlationId;
+    private String originalMessageId;
 
-    public String getCorrelationId()
+    public String getOriginalMessageId()
     {
-        return correlationId;
+        return originalMessageId;
     }
 
-    public void setCorrelationId(String correlationId)
+    public void setOriginalMessageId(String originalMessageId)
     {
-        this.correlationId = correlationId;
+        this.originalMessageId = originalMessageId;
     }
 
     private FeedbackStatusCode statusCode;


### PR DESCRIPTION
Earlier today, I was attempting to correlate messageIds to specific feedback messages. However, the correlationId was empty due to the setting of a blank string in FeedbackBatchMessage's static parse() method. 

After analysis of the JSON object, which I have attached for reference, there exists an originalMessageId, which I surmise to correlate with the message that the feedback is associated with. Hence, I've made two edits to two files.

[FeedbackJSONResponse.txt](https://github.com/Azure/azure-iot-sdks/files/416887/FeedbackJSONResponse.txt)
