### PR TITLE
Adding further options to limit built files and honoring other build options

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -84,6 +84,11 @@ if(NOT "${compileOption_CXX}" STREQUAL "OFF")
 endif()
 
 add_subdirectory(azure-c-shared-utility)
+
+# Check we have at least one valid transport
+if(NOT ${use_amqp} AND NOT ${use_mqtt} AND NOT ${use_http})
+    message(FATAL_ERROR "must provide at least one valid transport. At least one of use_amqtp, use_mqtt or use_http options must be set to ON")
+endif()
 if(${use_amqp})
     add_subdirectory(azure-uamqp-c)
 endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -43,6 +43,8 @@ option(compileOption_CXX "passes a string to the command line of the C++ compile
 option(build_python "builds the Python native iothub_client module" OFF)
 option(build_javawrapper "builds the native iothub_client library for java C wrapper" OFF)
 option(dont_use_uploadtoblob "set dont_use_uploadtoblob to ON if the functionality of upload to blob is to be excluded, OFF otherwise. It requires HTTP" OFF)
+option(build_samples "set to OFF to not build samples" ON)
+option(build_service_client "set to OFF to not build the iothub_service_client" ON)
 
 #check for conflicting options
 if(NOT ${dont_use_uploadtoblob} AND NOT ${use_http})
@@ -82,8 +84,12 @@ if(NOT "${compileOption_CXX}" STREQUAL "OFF")
 endif()
 
 add_subdirectory(azure-c-shared-utility)
-add_subdirectory(azure-uamqp-c)
-add_subdirectory(azure-umqtt-c)
+if(${use_amqp})
+    add_subdirectory(azure-uamqp-c)
+endif()
+if(${use_mqtt})
+    add_subdirectory(azure-umqtt-c)
+endif()
 
 enable_testing()
 

--- a/c/build_all/linux/build.sh
+++ b/c/build_all/linux/build.sh
@@ -14,6 +14,8 @@ build_http=ON
 build_mqtt=ON
 use_wsio=OFF
 skip_unittests=OFF
+build_samples=ON
+build_service_client=ON
 build_python=OFF
 build_javawrapper=OFF
 run_valgrind=0
@@ -36,6 +38,8 @@ usage ()
     echo " --no-http                     do no build HTTP transport and samples"
     echo " --no-mqtt                     do no build MQTT transport and samples"
     echo " --no-make                     do not run make after cmake"
+    echo " --skip-samples                do not build samples"
+    echo " --skip-service-client         do not build iothub service client"
     echo " --use-websockets              Enables the support for AMQP over WebSockets."
     echo " --toolchain-file <file>       pass cmake a toolchain file for cross compiling"
     echo " --install-path-prefix         alternative prefix for make install"
@@ -86,6 +90,8 @@ process_args ()
               "--no-amqp" ) build_amqp=OFF;;
               "--no-http" ) build_http=OFF;;
               "--no-mqtt" ) build_mqtt=OFF;;
+              "--skip-samples" ) build_samples=OFF;;
+              "--skip-service-client" ) build_service_client=OFF;;
               "--no-make" ) make=false;;
               "--use-websockets" ) use_wsio=ON;;
               "--build-python" ) save_next_arg=3;;
@@ -115,7 +121,7 @@ process_args $*
 rm -r -f $build_folder
 mkdir -p $build_folder
 pushd $build_folder
-cmake $toolchainfile $cmake_install_prefix -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Duse_wsio:BOOL=$use_wsio -Dskip_unittests:BOOL=$skip_unittests -Dbuild_python:STRING=$build_python -Dbuild_javawrapper:BOOL=$build_javawrapper $build_root
+cmake $toolchainfile $cmake_install_prefix -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Duse_wsio:BOOL=$use_wsio -Dskip_unittests:BOOL=$skip_unittests -Dbuild_python:STRING=$build_python -Dbuild_javawrapper:BOOL=$build_javawrapper -Dbuild_samples:BOOL=$build_samples -Dbuild_service_client:BOOL=$build_service_client $build_root
 
 if [ "$make" = true ]
 then

--- a/c/iothub_client/CMakeLists.txt
+++ b/c/iothub_client/CMakeLists.txt
@@ -229,19 +229,21 @@ add_library(iothub_client
 )
 linkSharedUtil(iothub_client)
 
-# Don't build samples under Win32 ARM for now
-if(WIN32)
-# Build samples for WEC 2013 for both ARM and x86 processsor types
-  if(WINCE) 
-    add_subdirectory(samples)
-  else()
-    if (NOT ${ARCHITECTURE} STREQUAL "ARM")
-    add_subdirectory(samples)
+if(${build_samples})
+    # Don't build samples under Win32 ARM for now
+    if(WIN32)
+    # Build samples for WEC 2013 for both ARM and x86 processsor types
+    if(WINCE) 
+        add_subdirectory(samples)
+    else()
+        if (NOT ${ARCHITECTURE} STREQUAL "ARM")
+        add_subdirectory(samples)
+        endif()
     endif()
-  endif()
-    
-else()
-    add_subdirectory(samples)
+        
+    else()
+        add_subdirectory(samples)
+    endif()
 endif()
 
 

--- a/c/iothub_service_client/CMakeLists.txt
+++ b/c/iothub_service_client/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(iothub_service_client ${iothub_service_client_c_files} ${iothub_serv
 
 target_link_libraries(iothub_service_client uamqp)
 
-if (NOT ${ARCHITECTURE} STREQUAL "ARM")
+if (NOT ${ARCHITECTURE} STREQUAL "ARM" AND ${build_samples})
 	add_subdirectory(samples)
 endif()
 

--- a/c/serializer/CMakeLists.txt
+++ b/c/serializer/CMakeLists.txt
@@ -62,12 +62,14 @@ add_library(
 serializer ${serializer_c_files} ${serializer_h_files}
 )
 
-if(WIN32)
-	if (NOT ${ARCHITECTURE} STREQUAL "ARM")
+if(${build_samples})
+	if(WIN32)
+		if (NOT ${ARCHITECTURE} STREQUAL "ARM")
+			add_subdirectory(samples)
+		endif()
+	else()
 		add_subdirectory(samples)
 	endif()
-else()
-	add_subdirectory(samples)
 endif()
 
 if(NOT IN_OPENWRT)

--- a/python/build_all/linux/build.sh
+++ b/python/build_all/linux/build.sh
@@ -31,8 +31,7 @@ process_args()
 process_args $*
 
 # instruct C builder to include python library and to skip tests
-
-./c/build_all/linux/build.sh --build-python $PYTHON_VERSION --skip-unittests $*
+./c/build_all/linux/build.sh --build-python $PYTHON_VERSION --skip-unittests --skip-samples --skip-service-client $*
 [ $? -eq 0 ] || exit $?
 cd $build_root
 


### PR DESCRIPTION
I was using this library as a submodule and linking via make and noticing the samples were built and even though I had disabled MQTT as I was just using AMQP these targets were still getting built.

Added options that default to behaviour before change, but allows these other directories to be skipped. Reduces build times when just building the library.
