### PR TITLE
Iot hub java memory leak

### DIFF
--- a/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/amqps/AmqpsIotHubConnection.java
+++ b/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/amqps/AmqpsIotHubConnection.java
@@ -240,7 +240,9 @@ public final class AmqpsIotHubConnection extends BaseHandler
                 if (!this.executorService.awaitTermination(maxWaitTimeForTerminateExecutor, TimeUnit.SECONDS)) {
                     this.executorService.shutdownNow(); // Cancel currently executing tasks
                     // Wait a while for tasks to respond to being cancelled
-                    if (!this.executorService.awaitTermination(maxWaitTimeForTerminateExecutor, TimeUnit.SECONDS)){}
+                    if (!this.executorService.awaitTermination(maxWaitTimeForTerminateExecutor, TimeUnit.SECONDS)){
+                        System.err.println("Pool did not terminate");
+                    }
                 }
             } catch (InterruptedException ie) {
                 // (Re-)Cancel if current thread also interrupted
@@ -615,6 +617,7 @@ public final class AmqpsIotHubConnection extends BaseHandler
             {
                 try
                 {
+                    this.close();
                     System.out.println("Lost connection to the server. Reconnection attempt " + currentReconnectionAttempt++ + "...");
                     Thread.sleep(TransportUtils.generateSleepInterval(currentReconnectionAttempt));
                 }

--- a/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/amqps/IotHubReactor.java
+++ b/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/amqps/IotHubReactor.java
@@ -13,7 +13,6 @@ import java.util.concurrent.Future;
 public class IotHubReactor
 {
     Reactor reactor;
-
     Future futureReactor;
 
     public IotHubReactor(Reactor reactor)
@@ -29,7 +28,6 @@ public class IotHubReactor
     {
         this.reactor.setTimeout(10);
         this.reactor.start();
-        System.out.println("Running: " + Thread.currentThread().getName() + " id: " + Thread.currentThread().getId());
         while(this.reactor.process())
         {
             if( Thread.currentThread().isInterrupted() || futureReactor.isCancelled() )
@@ -38,6 +36,5 @@ public class IotHubReactor
             }
         }
         this.reactor.stop();
-        System.out.println("Closing: " + Thread.currentThread().getName() + " id: " + Thread.currentThread().getId());
     }
 }

--- a/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/amqps/IotHubReactor.java
+++ b/java/device/iothub-java-client/src/main/java/com/microsoft/azure/iothub/transport/amqps/IotHubReactor.java
@@ -8,26 +8,36 @@ package com.microsoft.azure.iothub.transport.amqps;
 import org.apache.qpid.proton.engine.HandlerException;
 import org.apache.qpid.proton.reactor.Reactor;
 
+import java.util.concurrent.Future;
+
 public class IotHubReactor
 {
     Reactor reactor;
+
+    Future futureReactor;
 
     public IotHubReactor(Reactor reactor)
     {
         this.reactor = reactor;
     }
 
+    public void IotHubReactorSetFutureReactor (Future futureReactor)
+    {
+        this.futureReactor = futureReactor;
+    }
     public void run() throws HandlerException
     {
         this.reactor.setTimeout(10);
         this.reactor.start();
+        System.out.println("Running: " + Thread.currentThread().getName() + " id: " + Thread.currentThread().getId());
         while(this.reactor.process())
         {
-            if(Thread.currentThread().isInterrupted())
+            if( Thread.currentThread().isInterrupted() || futureReactor.isCancelled() )
             {
-                return;
+                break;
             }
         }
         this.reactor.stop();
+        System.out.println("Closing: " + Thread.currentThread().getName() + " id: " + Thread.currentThread().getId());
     }
 }


### PR DESCRIPTION
Memory leak fix for IoT Hub Device Client Java implementation as per discussion in ticket 720 and with Microsoft Engineer Priyanka Mathur on 26th Aug 2016:
"

In IotHubReactor.java, only checking if the current Thread is interrupted is not sufficient because, from what I understand, a Thread can sometimes ignores the interrupt signal. Also, cancelling future task by reactorFuture.cancel (in AmpqIotHubConnection.java , close() ) is also not sufficient. All these methods are attempts to close a running Thread, and the Thread can (most of the time) ignore the request. 

So there is a need to manually check whether the Future object is cancelled while the thread is running. I've added futureReactor.isCancelled() in run() method of IotHubReactor class to exit the thread accordingly. Also, I've used break instead of return to call reactor.stop() method before exiting run().

Please let me know if this fix is valid on your set up and whether it will be included in the next release of the IoT Hub SDK.
"

I am looking forward to hearing from the IoT Hub Team.

Best wishes,