### PR TITLE
Use GNU install directories

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -13,6 +13,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full --error-exitcode=1")
 endif()
 
+# Set CMAKE_INSTALL_* if not defined
+include(GNUInstallDirs)
+
 include (CTest)
 
 if(MSVC)

--- a/c/iothub_client/CMakeLists.txt
+++ b/c/iothub_client/CMakeLists.txt
@@ -258,8 +258,8 @@ if(WIN32)
 else()
     install (TARGETS 
         ${iothub_client_libs} 
-        DESTINATION lib)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install (FILES 
         ${iothub_client_h_install_files} 
-        DESTINATION include/azureiot)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
 endif (WIN32)

--- a/c/serializer/CMakeLists.txt
+++ b/c/serializer/CMakeLists.txt
@@ -77,6 +77,6 @@ endif()
 
 if(WIN32)
 else()
-    install (TARGETS serializer DESTINATION lib)
-    install (FILES ${serializer_h_files} DESTINATION include/azureiot)
+    install (TARGETS serializer DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install (FILES ${serializer_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
 endif (WIN32)


### PR DESCRIPTION
Use GNU install directory variables to determine where to install files on Linux. This allows distros or users to override install locations based on their own conventions. By default GNU coding standard is adhered to.
