### PR TITLE
Don't ignore 'skip_unittests'

### DIFF
--- a/c/iothub_client/CMakeLists.txt
+++ b/c/iothub_client/CMakeLists.txt
@@ -248,10 +248,9 @@ else()
     add_subdirectory(samples)
 endif()
 
-
-if(NOT IN_OPENWRT)
 # Disable tests for OpenWRT
-add_subdirectory(tests)
+if(NOT IN_OPENWRT AND NOT ${skip_unittests})
+	add_subdirectory(tests)
 endif()
 
 if(WIN32)

--- a/c/iothub_service_client/CMakeLists.txt
+++ b/c/iothub_service_client/CMakeLists.txt
@@ -59,8 +59,8 @@ if (NOT ${ARCHITECTURE} STREQUAL "ARM")
 	add_subdirectory(samples)
 endif()
 
-if(NOT IN_OPENWRT)
 # Disable tests for OpenWRT
-add_subdirectory(tests)
+if(NOT IN_OPENWRT AND NOT ${skip_unittests})
+	add_subdirectory(tests)
 endif()
 

--- a/c/serializer/CMakeLists.txt
+++ b/c/serializer/CMakeLists.txt
@@ -70,9 +70,9 @@ else()
 	add_subdirectory(samples)
 endif()
 
-if(NOT IN_OPENWRT)
-# Disable tests and samples for OpenWRT
-add_subdirectory(tests)
+# Disable tests for OpenWRT
+if(NOT IN_OPENWRT AND NOT ${skip_unittests})
+	add_subdirectory(tests)
 endif()
 
 if(WIN32)

--- a/python/device/iothub_client_python/CMakeLists.txt
+++ b/python/device/iothub_client_python/CMakeLists.txt
@@ -76,4 +76,7 @@ if(${use_mqtt})
 endif()
 
 add_subdirectory(src)
-add_subdirectory(test)
+
+if(NOT ${skip_unittests})
+    add_subdirectory(test)
+endif()


### PR DESCRIPTION
Some components do not adhere to the 'skip_unittests' option.
