### PR TITLE
Fixed GateKeeperDelegatingHandler.CloseAsync() Bug - Issue #821

### DIFF
--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/GateKeeperDelegatingHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/GateKeeperDelegatingHandler.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
         /// <returns></returns>
         public override async Task CloseAsync()
         {
-            if (!this.TryCloseGate())
+            if (this.TryCloseGate())
             {
                 await base.CloseAsync();
             }

--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/GateKeeperDelegatingHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/GateKeeperDelegatingHandler.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             }
 
             localOpenTaskCompletionSource?.TrySetCanceled();
-            return true;
+            return this.open;
         }
 
         Task EnsureOpenedAsync(bool explicitOpen)


### PR DESCRIPTION
Resolution to issue #821: CloseAsync() Does Not Close IoT Hub Connection



