### PR TITLE
Python build issue

### DIFF
--- a/doc/get_started/python-devbox-setup.md
+++ b/doc/get_started/python-devbox-setup.md
@@ -39,7 +39,7 @@ The Python iothub_client supports python versions 2.7.x, 3.4.x or 3.5.x. Know th
 
 ###Known build issues: 
 
-1.) On building the Python client library (iothub_client.so) on Linux devices that have less than **1GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp` as shown below
+1.) On building the Python client library (`iothub_client.so`) on Linux devices that have less than **1GB** RAM, you may see build getting **stuck** at **98%** while building `iothub_client_python.cpp` as shown below
 
 ``[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o``
 

--- a/doc/get_started/python-devbox-setup.md
+++ b/doc/get_started/python-devbox-setup.md
@@ -39,11 +39,11 @@ The Python iothub_client supports python versions 2.7.x, 3.4.x or 3.5.x. Know th
 
 ###Known build issues: 
 
-1.) On building the Python library on Linux devices that have less than **1 GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp` as shown below
+1.) On building the Python client library (iothub_client.so) on Linux devices that have less than **1GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp` as shown below
 
 ``[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o``
 
-Check the memory consumption of the device using `free -m command` in another terminal window. If you are running out of memory while compiling this file, you may have to temporarily increase the **swap space** to that get more available memory to successfully build the Python client side device SDK Library.
+Check the **memory consumption** of the device using `free -m command` in another terminal window. If you are running out of memory while compiling this .CPP file, you may have to temporarily increase the **swap space** to get more available memory to successfully build the Python client side device SDK Library.
 
 2.) CentOS7: Only Python 2.7 is supported due to a missing boost-python3 library package
 

--- a/doc/get_started/python-devbox-setup.md
+++ b/doc/get_started/python-devbox-setup.md
@@ -39,14 +39,13 @@ The Python iothub_client supports python versions 2.7.x, 3.4.x or 3.5.x. Know th
 
 ###Known build issues: 
 
-1. On building the Python library on Linux devices that have less than **1 GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp` as shown below
+1.) On building the Python library on Linux devices that have less than **1 GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp` as shown below
 
-`[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o`
+``[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o``
 
 Check the memory consumption of the device using `free -m command` in another terminal window. If you are running out of memory while compiling this file, you may have to temporarily increase the **swap space** to that get more available memory to successfully build the Python client side device SDK Library.
 
-
-2. CentOS7: Only Python 2.7 is supported due to a missing boost-python3 library package
+2.) CentOS7: Only Python 2.7 is supported due to a missing boost-python3 library package
 
 <a name="windows-wheels"/>
 ## Install the Python iothub_client module on Windows from [PyPI] 

--- a/doc/get_started/python-devbox-setup.md
+++ b/doc/get_started/python-devbox-setup.md
@@ -38,7 +38,8 @@ The Python iothub_client supports python versions 2.7.x, 3.4.x or 3.5.x. Know th
 5. After a successful build, the `iothub_client.so` Python extension module is copied to the **python/device/samples** folder. Please follow instructions in [Sample applications](#samplecode) to run the Python samples.
 
 ###Known build issues: 
-1.On building the Python library on Linux devices that have less than **1 GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp`.  Example below
+
+1. On building the Python library on Linux devices that have less than **1 GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp` as shown below
 
 `[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o`
 

--- a/doc/get_started/python-devbox-setup.md
+++ b/doc/get_started/python-devbox-setup.md
@@ -43,7 +43,7 @@ The Python iothub_client supports python versions 2.7.x, 3.4.x or 3.5.x. Know th
 
 ``[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o``
 
-Check the **memory consumption** of the device using `free -m command` in another terminal window. If you are running out of memory while compiling this .CPP file, you may have to temporarily increase the **swap space** to get more available memory to successfully build the Python client side device SDK Library.
+If you run into this issue, check the **memory consumption** of the device using `free -m command` in another terminal window during that time. If you are running out of memory while compiling iothub_client_python.cpp file, you may have to temporarily increase the **swap space** to get more available memory to successfully build the Python client side device SDK Library.
 
 2.) CentOS7: Only Python 2.7 is supported due to a missing boost-python3 library package
 

--- a/doc/get_started/python-devbox-setup.md
+++ b/doc/get_started/python-devbox-setup.md
@@ -43,7 +43,7 @@ The Python iothub_client supports python versions 2.7.x, 3.4.x or 3.5.x. Know th
 
 ``[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o``
 
-If you run into this issue, check the **memory consumption** of the device using `free -m command` in another terminal window during that time. If you are running out of memory while compiling iothub_client_python.cpp file, you may have to temporarily increase the **swap space** to get more available memory to successfully build the Python client side device SDK Library.
+If you run into this issue, check the **memory consumption** of the device using `free -m command` in another terminal window during that time. If you are running out of memory while compiling iothub_client_python.cpp file, you may have to temporarily increase the **swap space** to get more available memory to successfully build the Python client side device SDK library.
 
 2.) CentOS7: Only Python 2.7 is supported due to a missing boost-python3 library package
 

--- a/doc/get_started/python-devbox-setup.md
+++ b/doc/get_started/python-devbox-setup.md
@@ -38,7 +38,13 @@ The Python iothub_client supports python versions 2.7.x, 3.4.x or 3.5.x. Know th
 5. After a successful build, the `iothub_client.so` Python extension module is copied to the **python/device/samples** folder. Please follow instructions in [Sample applications](#samplecode) to run the Python samples.
 
 ###Known build issues: 
-1. On some small footprint Linux devices, like a *Raspberry Pi* using Raspbian OS, the following build error may occur: `virtual memory exhausted: Cannot allocate memory`. In such a case please try to increase the swap file size on your platform and retry the build. (If swap increase did not work consider running build.sh using --skip-unittests --use-websockets parameters)
+1.On building the Python library on Linux devices that have less than **1 GB RAM**, you may see build getting stuck at **98%** while building `iothub_client_python.cpp`.  Example below
+
+`[ 98%] Building CXX object python/src/CMakeFiles/iothub_client_python.dir/iothub_client_python.cpp.o`
+
+Check the memory consumption of the device using `free -m command` in another terminal window. If you are running out of memory while compiling this file, you may have to temporarily increase the **swap space** to that get more available memory to successfully build the Python client side device SDK Library.
+
+
 2. CentOS7: Only Python 2.7 is supported due to a missing boost-python3 library package
 
 <a name="windows-wheels"/>


### PR DESCRIPTION
Updated build instructions for building Python SDK client library on  Linux based devices that have less than 1GB available physical memory.  