### PR TITLE
Exported Device into iothub.js and iothub.d.ts

### DIFF
--- a/node/service/iothub.d.ts
+++ b/node/service/iothub.d.ts
@@ -4,6 +4,7 @@
 export import Client = require('./lib/client');
 export import ConnectionString = require('./lib/connection_string');
 export import Registry = require('./lib/registry');
+export import Device = require('./lib/device');
 export import SharedAccessSignature = require('./lib/shared_access_signature');
 export import Amqp = require('./lib/amqp');
 export import AmqpWs = require('./lib/amqp_ws');

--- a/node/service/iothub.js
+++ b/node/service/iothub.js
@@ -14,6 +14,7 @@ module.exports = {
   Client: require('./lib/client.js'),
   ConnectionString: require('./lib/connection_string.js'),
   Registry: require('./lib/registry.js'),
+  Device: require('lib/device.js'),
   SharedAccessSignature: require('./lib/shared_access_signature.js'),
   Amqp: require('./lib/amqp.js'),
   AmqpWs: require('./lib/amqp_ws.js'),


### PR DESCRIPTION
iothub.Device is not a constructor at Object.<anonymous> (/Users/luis.valencia/Projects/IoTSamples/NodeJSIoTHelloWorld /CreateDeviceIdentity.js:7:14) #962

![image](https://cloud.githubusercontent.com/assets/22323656/20379628/4a3cc2c0-ac6b-11e6-8883-d57d653ef708.png)

this merge would eliminate issue #962 and also address errors shown in picture for typescript