### PR TITLE
Fix dmpattern samples

### DIFF
--- a/dmpatterns.md
+++ b/dmpatterns.md
@@ -9,6 +9,16 @@ The device management pattern samples support the following device management tu
 
 To learn more about Azure IoT Hub device management, see [Overview of Azure IoT Hub device management](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-device-management-overview/).
 
+## Installing the samples
+
+1. From the root directory of the repository, run the following commands:
+    ```
+    cd node/device/samples
+    npm install
+    cd ../../service/samples
+    npm install
+    ```
+
 ## Running the samples
 
 From the root directory of the repository, run through the following steps to see the device and service interacting to enable the device management patterns:
@@ -17,27 +27,26 @@ From the root directory of the repository, run through the following steps to se
 
 1. Start the device side first, as it will register the C2D method listener for reboot:
     ```
-    node \node\device\samples\dmpatterns_reboot_device.js <IotHub device connection string>
+    cd node/device/samples
+    node dmpatterns_reboot_device.js <IotHub device connection string>
     ```
 
 2. In a new terminal window, start the service side to initate the reboot:
-
     ```
-    node \node\service\samples\dmpatterns_reboot_service.js <IotHub connection string>
+    cd node/service/samples
+    node dmpatterns_reboot_service.js <IotHub connection string> <targetDeviceId>
     ```
-
 
 ### Firmware Update device management pattern:
 
 1. Start the device side first, as it will register the C2D method listener for firmware update:
-
     ```
-    node \node\device\samples\dmpatterns_fwupdate_device.js <IotHub device connection string>
+    cd node/device/samples
+    node dmpatterns_fwupdate_device.js <IotHub device connection string>
     ```
 
 2. In a new terminal window, start the service side to initate the firmware update:
-
     ```
-    node \node\service\samples\dmpatterns_fwupdate_service.js <IotHub connection string>
+    cd node/service/samples
+    node dmpatterns_fwupdate_service.js <IotHub connection string> <targetDeviceId>
     ```
-

--- a/node/device/samples/package.json
+++ b/node/device/samples/package.json
@@ -6,6 +6,7 @@
   "author": "Microsoft Corp.",
   "license": "MIT",
   "dependencies": {
+    "async": "^2.1.2",
     "azure-iot-device": "1.1.0",
     "azure-iot-device-amqp": "1.1.0",
     "azure-iot-device-http": "1.1.0",

--- a/node/service/samples/package.json
+++ b/node/service/samples/package.json
@@ -6,6 +6,7 @@
   "author": "Microsoft Corp.",
   "license": "MIT",
   "dependencies": {
+    "async": "^2.1.2",
     "azure-iothub": "1.1.0",
     "azure-storage": "^1.2.0"
   }


### PR DESCRIPTION
I went through dmpatterns.md and found a few problems:
1. The walkthrough doesn't instruct the user to run `npm install` in each of the sample directories, so the samples don't work when you run them.
2. The samples all have a dependency on the `async` package, which isn't listed in package.json. So even after the user does `npm install` the samples fail.
3. The service-side samples require a `targetDeviceId` argument that wasn't in the instructions.

I updated the MD file to include the missing instructions. I also updated the package manifests to include the `async` dependency.