### PR TITLE
Fix sas-token error

### DIFF
--- a/tools/iothub-explorer/iothub-explorer-sas-token.js
+++ b/tools/iothub-explorer/iothub-explorer-sas-token.js
@@ -41,7 +41,7 @@ registry.get(deviceId, function (err, device) {
   if (err)
     serviceError(err);
   else {
-    var key = device.authentication.SymmetricKey.primaryKey || device.authentication.SymmetricKey.secondaryKey;
+    var key = device.authentication.symmetricKey.primaryKey || device.authentication.symmetricKey.secondaryKey;
     if (!key) {
       inputError('Cannot create a SAS for this device. It does not use symmetric key authentication.');
     }


### PR DESCRIPTION
When I run
$ iothub-explorer sas-token <device-id>

it reports error:
“/usr/local/lib/node_modules/iothub-explorer/iothub-explorer-sas-token.j
s:44
var key = String(device.authentication.SymmetricKey.primaryKey) ||
String(device.authentication.SymmetricKey.secondaryKey);
^

TypeError: Cannot read property 'primaryKey' of undefined”

I changed “device.authentication.SymmetricKey.primaryKey” to
“device.authentication.symmetricKey.primaryKey” and the error is gone.