### PR TITLE
Make ErrorDelegatingHandler Cleanup return a Task

### DIFF
--- a/csharp/device/Microsoft.Azure.Devices.Client/Transport/ErrorDelegatingHandler.cs
+++ b/csharp/device/Microsoft.Azure.Devices.Client/Transport/ErrorDelegatingHandler.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                     }
                     catch (Exception ex) when (IsTransportHandlerStillUsable(ex))
                     {
-                        this.Reset(openCompletionBeforeOperationStarted, handlerBeforeOperationStarted);
+                        await this.Reset(openCompletionBeforeOperationStarted, handlerBeforeOperationStarted);
                         throw;
                     }
                     catch (Exception ex) when (!ex.IsFatal())
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                         }
                         throw new IotHubClientTransientException("Transient error occured, please retry.", ex);
                     }
-                    this.Reset(openCompletionBeforeOperationStarted, handlerBeforeOperationStarted);
+                    await this.Reset(openCompletionBeforeOperationStarted, handlerBeforeOperationStarted);
                     if (ex is IotHubClientTransientException)
                     {
                         throw;
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 }
                 else
                 {
-                    this.Reset(openCompletionBeforeOperationStarted, handlerBeforeOperationStarted);
+                    await this.Reset(openCompletionBeforeOperationStarted, handlerBeforeOperationStarted);
                     throw;
                 }
             }
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Devices.Client.Transport
             return exception.Unwind(true).Any(e => TransientExceptions.Contains(e.GetType()));
         }
 
-        void Reset(TaskCompletionSource<int> openCompletionBeforeOperationStarted, IDelegatingHandler handlerBeforeOperationStarted)
+        async Task Reset(TaskCompletionSource<int> openCompletionBeforeOperationStarted, IDelegatingHandler handlerBeforeOperationStarted)
         {
             if (openCompletionBeforeOperationStarted == this.openCompletion)
             {
@@ -196,12 +196,12 @@ namespace Microsoft.Azure.Devices.Client.Transport
                 if (Interlocked.CompareExchange(ref this.openCompletion, null, openCompletionBeforeOperationStarted) == openCompletionBeforeOperationStarted)
 #pragma warning restore 420
                 {
-                    Cleanup(handlerBeforeOperationStarted);
+                    await Cleanup(handlerBeforeOperationStarted);
                 }
             }
         }
 
-        static async void Cleanup(IDelegatingHandler handler)
+        static async Task Cleanup(IDelegatingHandler handler)
         {
             try
             {


### PR DESCRIPTION
When using the C# DeviceClient in a ASP.NET context, I'm sometimes getting exceptions (InvalidOperationException) in the ErrorDelegatingHandlers Cleanup method. It looks like this is because the AspNetSynchronizationContext [does not like async void](https://referencesource.microsoft.com/#system.web/AspNetSynchronizationContext.cs,108). As far as I can figure out/think of, nothing breaks by changing the signature of the Cleanup Method so that it returns an awaitable task. 

```
An asynchronous operation cannot be started at this time. Asynchronous operations may only be started within an asynchronous handler or module or during certain events in the Page lifecycle. If this exception occurred while executing a Page, ensure that the Page is marked <%@ Page Async="true" %>. This exception may also indicate an attempt to call an "async void" method, which is generally unsupported within ASP.NET request processing. Instead, the asynchronous method should return a Task, and the caller should await it.
```

```callstack
System.InvalidOperationException:
   at System.Web.AspNetSynchronizationContext.OperationStarted (System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Create (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.Cleanup (Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler.Reset (Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at Microsoft.Azure.Devices.Client.Transport.ErrorDelegatingHandler+<ExecuteWithErrorHandlingAsync>d__14`1.MoveNext (Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at Microsoft.Azure.Devices.Client.Transport.RetryDelegatingHandler+<ReceiveAsync>d__11.MoveNext (Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at Microsoft.Azure.Devices.Client.Transport.GateKeeperDelegatingHandler+<ReceiveAsync>d__7.MoveNext (Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at MyCompany.InfraStructure.IotHub.IotHubService+<ReceiveAsync>d__8.MoveNext (MyCompany.InfraStructure.IotHub, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at MyCompany.Infrastructure.ReceiveFromIotHub+<IotHubMessage>d__19.MoveNext (MyCompany.Infrastructure.IotHub, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
```

It's hard to reproduce this problem in an Unit Test due to the need af an AspNetSynchronizationContext and this rare openCompletion situation. But if you want me to, I'll try to create an app or test to show this...